### PR TITLE
Correct CLI corruption of json

### DIFF
--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -16,7 +16,7 @@ import argparse
 import subprocess
 import re
 import collections
-from six import iteritems, string_types, itervalues, u
+from six import iteritems, string_types, itervalues, u, text_type
 from six.moves import input
 from firecloud import api as fapi
 from firecloud import fccore
@@ -1608,7 +1608,10 @@ def printToCLI(value):
     elif isinstance(value, (list, tuple)):
         list(map(lambda v: print(v), value))
     elif not isinstance(value, int):
-        print(u("{0}".format(value)))
+        if isinstance(value, text_type):
+            print(value)
+        else:
+            print(u("{0}".format(value)))
     return retval
 
 #################################################

--- a/firecloud/tests/echo.wdl
+++ b/firecloud/tests/echo.wdl
@@ -15,5 +15,5 @@ task echo_task {
 }
 
 workflow echo {
-	call echo_task {input: message="Hello, from the simple GDAC echo task"}
+	call echo_task
 }


### PR DESCRIPTION
Prevent removal of escape characters from strings and corrupting json.

Update tests to ensure json is not corrupted when retrieved from the CLI
via config_get.

Fixes #39