### PR TITLE
Allow Service Account FireCloud users to run FISS

### DIFF
--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -35,6 +35,8 @@ def _fiss_access_headers(headers=None):
 
     """
     credentials = GoogleCredentials.get_application_default()
+    # We need to request userinfo.profile and userinfo.email if we are using a service account to run FISS
+    credentials = credentials.create_scoped(['https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email'])
     access_token = credentials.get_access_token().access_token
     fiss_headers = {"Authorization" : "bearer " + access_token}
     fiss_headers["User-Agent"] = FISS_USER_AGENT


### PR DESCRIPTION
I was trying to use FISS to call FireCloud using a service account that I had registered for use in FireCloud.  I realized I was not able to get through the proxy because the service account was not requesting the right scopes.  Added the correct userinfo.profile and userinfo.email scopes that are required for a service account to get through the proxies.  This has no negative effect upon a regular user of FISS.