### PR TITLE
add snapshot comment to meth_new

### DIFF
--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -770,8 +770,6 @@ def update_repository_method(namespace, method, synopsis, wdl, doc=None,
     if doc is not None:
         with open (doc, 'r') as df:
             doc = df.read()
-    else:
-        doc = ""
 
     body = {
         "namespace": namespace,
@@ -783,7 +781,8 @@ def update_repository_method(namespace, method, synopsis, wdl, doc=None,
         "snapshotComment": comment
     }
 
-    return __post("methods", json=body)
+    return __post("methods",
+                  json={key: value for key, value in body.items() if value})
 
 def delete_repository_method(namespace, name, snapshot_id):
     """Redacts a method and all of its associated configurations.

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -747,7 +747,8 @@ def get_repository_method(namespace, method, snapshot_id):
     uri = "methods/{0}/{1}/{2}".format(namespace, method, snapshot_id)
     return __get(uri)
 
-def update_repository_method(namespace, method, synopsis, wdl, doc=None):
+def update_repository_method(namespace, method, synopsis, wdl, doc=None,
+                             comment=""):
     """Create/Update workflow definition.
 
     FireCloud will create a new snapshot_id for the given workflow.
@@ -758,6 +759,7 @@ def update_repository_method(namespace, method, synopsis, wdl, doc=None):
         synopsis (str): short (<80 char) description of method
         wdl (file): Workflow Description Language file
         doc (file): (Optional) Additional documentation
+        comment (str): (Optional) Comment specific to this snapshot
 
     Swagger:
         https://api.firecloud.org/#!/Method_Repository/post_api_methods
@@ -777,7 +779,8 @@ def update_repository_method(namespace, method, synopsis, wdl, doc=None):
         "entityType": "Workflow",
         "payload": wdl_payload,
         "documentation": doc,
-        "synopsis": synopsis
+        "synopsis": synopsis,
+        "snapshotComment": comment
     }
 
     return __post("methods", json=body)

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -307,10 +307,12 @@ def sset_delete(args):
 def meth_new(args):
     """ Submit a new workflow (or update) to the methods repository. """
     r = fapi.update_repository_method(args.namespace, args.method,
-                                    args.synopsis, args.wdl, args.doc)
+                                      args.synopsis, args.wdl, args.doc,
+                                      args.comment)
     fapi._check_response_code(r, 201)
     if fcconfig.verbosity:
-        print("Method %s installed to project %s" % (args.method,args.namespace))
+        print("Method %s installed to project %s" % (args.method,
+                                                     args.namespace))
     return 0
 
 @fiss_cmd
@@ -1871,6 +1873,9 @@ def main(argv=None):
     syn_help = 'Short (<80 chars) description of method'
     subp.add_argument('-s', '--synopsis', help=syn_help)
     subp.add_argument('--doc', help='Optional documentation file <10Kb')
+    subp.add_argument('-c', '--comment', metavar='SNAPSHOT_COMMENT',
+                      help='Optional comment specific to this snapshot',
+                      default='')
     subp.set_defaults(func=meth_new)
 
     # Redact a method


### PR DESCRIPTION
```POST /api/methods``` has added a snapshotComment field. This keeps our client up-to-date.