### PR TITLE
Remove manifest log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.project
 /.pydevproject
 /.settings/
+build/*
+dist/*
+firecloud.egg-info/*

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1274,24 +1274,16 @@ def _attr_lrem(attr, value):
     }
 
 # cloud functions
-def get_bucket(fileInCloud, downloadDir, filename, manifestLogFile=None):
+# TODO: change name since it doesn't retrieve a bucket but a file living in a bucket
+def get_bucket(fileInCloud, downloadDir, filename):
     """Downloads a file in cloud using multi-threaded/multi-processing copy, which
     is what the -m option provides.
     Args:
         fileInCloud: the link to a file in a Google bucket.
         downloadDir: the local directory to save the file.
         filename: the name of the zip file to be saved as.
-        manifestLogFile: the name of a Google manifest log file. By specifying
-            the manifestLogFile, logging is turned on, which outputs a manifest
-            log file with detailed information about each item that is copied using
-            'gsutil cp'. For more information (including what happens if the log
-            file already exists,), reference GCP's documentation:
-            https://cloud.google.com/storage/docs/gsutil/commands/cp
     """
     file = os.path.join(downloadDir, filename)
-    if manifestLogFile:
-        cmd = "gsutil -m cp -L {} {} {}".format(manifestLogFile, fileInCloud, file)
-    else:
-        cmd = "gsutil -m cp {} {}".format(fileInCloud, file)
+    cmd = "gsutil -m cp {} {}".format(fileInCloud, file)
     # TODO: use subprocess instead
     os.system(cmd)


### PR DESCRIPTION
Per our conversation with Mike today, we decided to not provide users with the `-L` option when using `gsutil cp`. One major challenge was that if the log file already exists and files/objects are marked in the existing log file as having been successfully copied will be ignore, then even if you delete the downloaded file locally, `gsutil cp` will still skip  downloading the file.