### PR TITLE
Fixed entity_import

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
+v0.16.8 -  Hotfix; entity_import corrected to only strip newline characters.
 
 v0.16.7 -  Enabled LL and HL access to the linkExistingEntities field of the
            copy entities API, enabling copying set entities to workspaces that

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -12,6 +12,7 @@ import os
 import time
 from inspect import getsourcelines
 from traceback import print_tb as print_traceback
+from io import open
 import argparse
 import subprocess
 import re
@@ -222,7 +223,7 @@ def entity_import(args):
 
     with open(args.tsvfile) as tsvf:
         headerline = tsvf.readline().strip()
-        entity_data = [l.strip() for l in tsvf]
+        entity_data = [l.rstrip('\n') for l in tsvf]
 
     return _batch_load(project, workspace, headerline, entity_data, chunk_size)
 


### PR DESCRIPTION
* Override `open` built-in with `io.open`, to enable universal newline default behavior (and improve python 2/3 compatibility).
* Only strip newline characters from line ends of entity TSVs rather than all whitespace (Fixes #74).