### PR TITLE
Hotfix: Fixed bug preventing gcloud tool installation.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.15 - Hotfix: Fixed bug preventing gcloud tool installation.
+
 v0.16.14 - Hotfix: Fixed warning messages that would cause errors if executed.
 
 v0.16.13 - Dockerfile updated to use local files rather than pull from pypi;

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.14"
+__version__ = "0.16.15"

--- a/setup.py
+++ b/setup.py
@@ -76,10 +76,10 @@ class InstallGcloudCommand(Command):
                     output = subprocess.check_output([gcloud_install_cmd,
                                                       self.silent],
                                                      stderr=subprocess.STDOUT)
-                    log.info(six.u(output.decode()))
+                    log.info(output.decode('utf-8'))
                 except subprocess.CalledProcessError as cpe:
                     log.warn(u' '.join(cpe.cmd) + u":\n\t" +
-                             six.u(cpe.output.decode()))
+                             cpe.output.decode('utf-8'))
                 
         elif self.curl is not None and self.bash is not None:
             try:
@@ -91,17 +91,17 @@ class InstallGcloudCommand(Command):
                         gcloud_install_cmd = os.path.join(tmpdir,
                                                           'installer.sh')
                         with open(gcloud_install_cmd, 'w') as gcloud_install_fd:
-                            gcloud_install_fd.write(script)
+                            gcloud_install_fd.write(script.decode('utf-8'))
                         output = subprocess.check_output([self.bash,
                                                           gcloud_install_cmd,
                                                           self.silent],
                                                          stderr=subprocess.STDOUT)
-                        log.info(six.u(output.decode()))
+                        log.info(output.decode('utf-8'))
                 else:
                     log.warn("Unable to download installer script. " + warn_msg)
             except subprocess.CalledProcessError as cpe:
                 log.warn(u' '.join(cpe.cmd) + u":\n\t" +
-                         six.u(cpe.output.decode()))
+                         cpe.output.decode('utf-8'))
         else:
             log.warn("Unable to find curl and/or bash. " + warn_msg)
 


### PR DESCRIPTION
@lukwam reported an issue building the docker image. Strangely, this worked for me before, but no longer did when I tested independently. 

The issue will also likely break installation on machines that don't have gcloud tools already installed.

This fix works for both python 2 and python 3.