### PR TITLE
expand entity list capabilities, tests & performance/robustness for large calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,9 @@ SHELL=/bin/bash
 __FILE__=$(lastword $(MAKEFILE_LIST))
 __PATH__=$(abspath $(dir $(__FILE__)))
 ROOT=$(__PATH__)
-PYTHON_HOME=$(shell $(ROOT)/util/findPython.sh)
+PYTHON_HOME=$(shell $(ROOT)/util/findPython.sh python$(PYTHON_VER))
 PYLINT=$(ROOT)/util/pylint_wrap.sh
 
-ifeq ($(MAKELEVEL),0)
-$(info Using Python from $(PYTHON_HOME))
-endif
 DEST=$(PYTHON_HOME)
 BIN_DIR=$(DEST)/bin                 # Python virtual environment here
 PYTHON=$(DEST)/bin/python$(PYTHON_VER)
@@ -20,6 +17,8 @@ VERBOSITY_NOSE=3
 VERBOSITY_FISS=0
 HIGHLEVEL_TESTS=--tests=firecloud/tests/highlevel_tests.py
 LOWLEVEL_TESTS=--tests=firecloud/tests/lowlevel_tests.py
+
+$(info Now using Python from $(PYTHON))
 
 help:
 	@echo
@@ -54,7 +53,13 @@ WHICH=
 test_one:
 	@# Example: make test_one WHICH=space_lock_unlock
 	@# Example: make test_one WHICH=ping VERBOSITY_FISS=1 (shows API calls)
+	@# Example: make test_one WHICH=sample_list REUSE_SPACE=true (see below)
 	@$(MAKE) invoke_tests TESTS=$(HIGHLEVEL_TESTS):TestFISSHighLevel.test_$(WHICH)
+
+# By default the tests create, populate & eventually delete a custom workspace.
+# To change this, set REUSE_SPACE to any value, either here or on CLI; then,
+# after running tests the space will be kept AND subsequent invocations will
+# run faster by not re-creating the space and/or re-loading data into it
 
 invoke_tests:
 	@FISS_TEST_VERBOSITY=$(VERBOSITY_FISS) \

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,14 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.16 - Added pair_list HL command; enlarged scope of applicability of
+           sample_list, to not only workspaces but all sample container
+           types: pair, sample_set, workspace, participant; added pair_list
+           HL function and new tests for both [pair,sample]_list; internal
+           HL function __get_entities now paginates by default, to enable
+           more calls to complete robustly; HL tests can now REUSE_SPACE for
+           faster execution during repeated testing
+
 v0.16.15 - Hotfix: Fixed bug preventing gcloud tool installation.
 
 v0.16.14 - Hotfix: Fixed warning messages that would cause errors if executed.

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.15"
+__version__ = "0.16.16"

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ setup(
         'pydot',
         'requests[security]',
         'six',
+        'nose',
         'pylint==1.7.2'
     ],
     classifiers = [


### PR DESCRIPTION
sample_list now works for all sample container types, not just workspaces; added pair_list; 2 new HL tests; and capability to REUSE_SPACE between test invocations; all HL __get_entities requests are now paged, to improve performance & robustness for large datasets