### PR TITLE
New WDL extraction capabilities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,11 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.20 - Updated LL command get_repository_method with documentation link and
+           new parameter wdl_only; new HL commands config_wdl and meth_wdl
+           use the updated LL command to retrieve WDL from the workspace config
+           and method repository respectively.
+
 v0.16.19 - Added config_diff HL command, HL command mop updated to work in
            Python 3 and fail with proper error message when workspace bucket is
            inaccessible.

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.19"
+__version__ = "0.16.20"

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -753,18 +753,21 @@ def get_repository_config(namespace, config, snapshot_id):
     uri = "configurations/{0}/{1}/{2}".format(namespace, config, snapshot_id)
     return __get(uri)
 
-def get_repository_method(namespace, method, snapshot_id):
+def get_repository_method(namespace, method, snapshot_id, wdl_only=False):
     """Get a method definition from the method repository.
 
     Args:
         namespace (str): Methods namespace
         method (str): method name
         version (int): snapshot_id of the method
+        wdl_only (bool): Exclude metadata
 
     Swagger:
-        UNDOCUMENTED
+        https://api.firecloud.org/#!/Method_Repository/get_api_methods_namespace_name_snapshotId
     """
-    uri = "methods/{0}/{1}/{2}".format(namespace, method, snapshot_id)
+    uri = "methods/{0}/{1}/{2}?onlyPayload={3}".format(namespace, method,
+                                                       snapshot_id,
+                                                       str(wdl_only).lower())
     return __get(uri)
 
 def update_repository_method(namespace, method, synopsis, wdl, doc=None,


### PR DESCRIPTION
Based on a feature request from @bknisbac:

Updated LL command get_repository_method with documentation link and new parameter wdl_only; new HL commands config_wdl and meth_wdl use the updated LL command to retrieve WDL from the workspace config and method repository respectively.