### PR TITLE
v0.16.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,14 +78,15 @@ reinstall:
 uninstall:
 	$(PIP) uninstall -y firecloud
 
-publish:
-	$(PYTHON) setup.py sdist upload && \
+publish: clean
+	$(PYTHON) setup.py sdist && \
+	twine upload dist/* && \
 	rm -rf build dist *.egg-info
 
 image:
 	docker build -t broadgdac/fiss .
 
 clean:
-	rm -rf build dist *.egg-info *~ */*~ *.pyc */*.pyc
+	rm -rf build dist .eggs *.egg-info *~ */*~ *.pyc */*.pyc
 
 .PHONY: help test test_cli test_one install release publish clean lintify

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,13 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.22 - LL: enabled namespace, name, and snapshot ID filtering for
+           repository listings, new command whoami returns user id; HL: updated
+           listing calls to enable new filters, added capability to set method
+           ACLs for groups, new command set_config_acl for setting ACLs on
+           configs in the methods repo; google-auth updated to use current
+           release.
+
 v0.16.21 - api.py will attempt to update credentials on a refresh error; typo
            fixes to several HL command descriptions; setup.py now requires a
            minimum version of setuptools (40.3.0); added Groups API to LL.

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.21"
+__version__ = "0.16.22"

--- a/firecloud/__init__.py
+++ b/firecloud/__init__.py
@@ -1,4 +1,7 @@
 import os
+import warnings
+warnings.filterwarnings('ignore', 'Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/')
+
 
 # Based on https://stackoverflow.com/a/379535
 def which(program):

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -465,7 +465,7 @@ def update_entity(namespace, workspace, etype, ename, updates):
 ### 1.2 Method Configurations
 ###############################
 
-def list_workspace_configs(namespace, workspace):
+def list_workspace_configs(namespace, workspace, allRepos=False):
     """List method configurations in workspace.
 
     Args:
@@ -477,7 +477,7 @@ def list_workspace_configs(namespace, workspace):
         DUPLICATE: https://api.firecloud.org/#!/Workspaces/listWorkspaceMethodConfigs
     """
     uri = "workspaces/{0}/{1}/methodconfigs".format(namespace, workspace)
-    return __get(uri)
+    return __get(uri, params={'allRepos': allRepos})
 
 def create_workspace_config(namespace, workspace, body):
     """Create method configuration in workspace.
@@ -678,24 +678,33 @@ def copy_config_to_repo(namespace, workspace, from_cnamespace,
 ### 1.3 Method Repository
 ###########################
 
-def list_repository_methods(name=None):
-    """List methods in the methods repository.
+def list_repository_methods(namespace=None, name=None, snapshotId=None):
+    """List method(s) in the methods repository.
+
+    Args:
+        namespace (str): Method Repository namespace
+        name (str): method name
+        snapshotId (int): method snapshot ID
 
     Swagger:
         https://api.firecloud.org/#!/Method_Repository/listMethodRepositoryMethods
     """
-    params = dict()
-    if name:
-        params['name'] = name
+    params = {k:v for (k,v) in locals().items() if v is not None}
     return __get("methods", params=params)
 
-def list_repository_configs():
+def list_repository_configs(namespace=None, name=None, snapshotId=None):
     """List configurations in the methods repository.
+
+    Args:
+        namespace (str): Method Repository namespace
+        name (str): config name
+        snapshotId (int): config snapshot ID
 
     Swagger:
         https://api.firecloud.org/#!/Method_Repository/listMethodRepositoryConfigurations
     """
-    return __get("configurations")
+    params = {k:v for (k,v) in locals().items() if v is not None}
+    return __get("configurations", params=params)
 
 def get_config_template(namespace, method, version):
     """Get the configuration template for a method.
@@ -703,7 +712,7 @@ def get_config_template(namespace, method, version):
     The method should exist in the methods repository.
 
     Args:
-        namespace (str): Methods namespace
+        namespace (str): Method's namespace
         method (str): method name
         version (int): snapshot_id of the method
 

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -465,7 +465,7 @@ def update_entity(namespace, workspace, etype, ename, updates):
 ### 1.2 Method Configurations
 ###############################
 
-def list_workspace_configs(namespace, workspace, allRepos=False):
+def list_workspace_configs(namespace, workspace):
     """List method configurations in workspace.
 
     Args:
@@ -477,7 +477,7 @@ def list_workspace_configs(namespace, workspace, allRepos=False):
         DUPLICATE: https://api.firecloud.org/#!/Workspaces/listWorkspaceMethodConfigs
     """
     uri = "workspaces/{0}/{1}/methodconfigs".format(namespace, workspace)
-    return __get(uri, params={'allRepos': allRepos})
+    return __get(uri)
 
 def create_workspace_config(namespace, workspace, body):
     """Create method configuration in workspace.
@@ -678,33 +678,24 @@ def copy_config_to_repo(namespace, workspace, from_cnamespace,
 ### 1.3 Method Repository
 ###########################
 
-def list_repository_methods(namespace=None, name=None, snapshotId=None):
-    """List method(s) in the methods repository.
-
-    Args:
-        namespace (str): Method Repository namespace
-        name (str): method name
-        snapshotId (int): method snapshot ID
+def list_repository_methods(name=None):
+    """List methods in the methods repository.
 
     Swagger:
         https://api.firecloud.org/#!/Method_Repository/listMethodRepositoryMethods
     """
-    params = {k:v for (k,v) in locals().items() if v is not None}
+    params = dict()
+    if name:
+        params['name'] = name
     return __get("methods", params=params)
 
-def list_repository_configs(namespace=None, name=None, snapshotId=None):
+def list_repository_configs():
     """List configurations in the methods repository.
-
-    Args:
-        namespace (str): Method Repository namespace
-        name (str): config name
-        snapshotId (int): config snapshot ID
 
     Swagger:
         https://api.firecloud.org/#!/Method_Repository/listMethodRepositoryConfigurations
     """
-    params = {k:v for (k,v) in locals().items() if v is not None}
-    return __get("configurations", params=params)
+    return __get("configurations")
 
 def get_config_template(namespace, method, version):
     """Get the configuration template for a method.
@@ -712,7 +703,7 @@ def get_config_template(namespace, method, version):
     The method should exist in the methods repository.
 
     Args:
-        namespace (str): Method's namespace
+        namespace (str): Methods namespace
         method (str): method name
         version (int): snapshot_id of the method
 

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -2177,7 +2177,7 @@ def main(argv=None):
 
     subp = subparsers.add_parser('meth_exists',
         description='Determine if named workflow exists in method repository')
-    subp.add_argument('method', help='name of method to search for In repository')
+    subp.add_argument('method', help='name of method to search for in repository')
     subp.set_defaults(func=meth_exists)
 
     # Configuration: list

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -438,7 +438,8 @@ def meth_acl(args):
 @fiss_cmd
 def meth_set_acl(args):
     """ Assign an ACL role to a list of users for a workflow. """
-    acl_updates = [{"user": user, "role": args.role} for user in args.users]
+    acl_updates = [{"user": user, "role": args.role} \
+                   for user in set(expand_fc_groups(args.users))]
 
     id = args.snapshot_id
     if not id:
@@ -460,10 +461,45 @@ def meth_set_acl(args):
         print("Updated ACL for {0}/{1}:{2}".format(args.namespace, args.method, id))
     return 0
 
+def expand_fc_groups(users):
+    """ If user is a firecloud group, return all members of the group.
+    Caveat is that only group admins may do this.
+    """
+    groups = None
+    for user in users:
+        fcgroup = None
+        if '@' not in user:
+            fcgroup = user
+        elif user.lower().endswith('@firecloud.org'):
+            if groups is None:
+                r = fapi.get_groups()
+                fapi._check_response_code(r, 200)
+                groups = {group['groupEmail'].lower():group['groupName'] \
+                          for group in r.json() if group['role'] == 'Admin'}
+            if user.lower() not in groups:
+                if fcconfig.verbosity:
+                    eprint("You do not have access to the members of {}".format(user))
+                yield user
+                continue
+            else:
+                fcgroup = groups[user.lower()]
+        else:
+            yield user
+            continue
+        r = fapi.get_group(fcgroup)
+        fapi._check_response_code(r, 200)
+        fcgroup_data = r.json()
+        for admin in fcgroup_data['adminsEmails']:
+            yield admin
+        for member in fcgroup_data['membersEmails']:
+            yield member
+
 @fiss_cmd
 def meth_list(args):
     """ List workflows in the methods repository """
-    r = fapi.list_repository_methods(name=args.name)
+    r = fapi.list_repository_methods(namespace=args.namespace,
+                                     name=args.method,
+                                     snapshotId=args.snapshot_id)
     fapi._check_response_code(r, 200)
 
     # Parse the JSON for the workspace + namespace
@@ -481,6 +517,8 @@ def meth_list(args):
 @fiss_cmd
 def meth_exists(args):
     '''Determine whether a given workflow is present in methods repo'''
+    args.namespace = None
+    args.snapshot_id = None
     return len(meth_list(args)) != 0
 
 @fiss_cmd
@@ -519,7 +557,7 @@ def config_stop(args):
 
 @fiss_cmd
 def config_list(args):
-    """ List configurations in the methods repository or a workspace. """
+    """ List configuration(s) in the methods repository or a workspace. """
     verbose = fcconfig.verbosity
     if args.workspace:
         if verbose:
@@ -532,7 +570,9 @@ def config_list(args):
     else:
         if verbose:
             print("Retrieving method configs from method repository")
-        r = fapi.list_repository_configs()
+        r = fapi.list_repository_configs(namespace=args.namespace,
+                                         name=args.config,
+                                         snapshotId=args.snapshot_id)
         fapi._check_response_code(r, 200)
 
     # Parse the JSON for the workspace + namespace
@@ -2093,22 +2133,31 @@ def main(argv=None):
     # List available methods
     subp = subparsers.add_parser('meth_list',
                                  description='List available workflows')
-    subp.add_argument('-n', '--name', default=None,required=False,
+    subp.add_argument('-m', '--method', default=None,
                       help='name of single workflow to search for (optional)')
+    subp.add_argument('-n', '--namespace', default=None,
+                      help='name of single workflow to search for (optional)')
+    subp.add_argument('-i', '--snapshot-id', default=None,
+                      help="Snapshot ID (version) of method/config")
     subp.set_defaults(func=meth_list)
 
     subp = subparsers.add_parser('meth_exists',
         description='Determine if named workflow exists in method repository')
-    subp.add_argument('name', help='name of method to search for In repository')
+    subp.add_argument('method', help='name of method to search for In repository')
     subp.set_defaults(func=meth_exists)
 
     # Configuration: list
     subp = subparsers.add_parser(
         'config_list', description='List available configurations')
-    subp.add_argument('-w', '--workspace', help='Workspace name',
-                      default=fcconfig.workspace, required=False)
+    subp.add_argument('-w', '--workspace', help='Workspace name')
     subp.add_argument('-p', '--project', default=fcconfig.project,
-                      help=proj_help, required=proj_required)
+                      help=proj_help)
+    subp.add_argument('-c', '--config', default=None,
+                      help='name of single workflow to search for (optional)')
+    subp.add_argument('-n', '--namespace', default=None,
+                      help='name of single workflow to search for (optional)')
+    subp.add_argument('-i', '--snapshot-id', default=None,
+                      help="Snapshot ID (version) of config (optional)")
     subp.set_defaults(func=config_list)
 
     # Configuration: delete
@@ -2206,7 +2255,7 @@ def main(argv=None):
     # cacl_parser.add_argument('name', help='Config name')
     # cacl_parser.add_argument('snapshot_id', help='Snapshot ID')
     # cacl_parser.add_argument('role', help='ACL role',
-    #                      choices=['OWNER', 'READER', 'WRITER', 'NO ACCESS'])
+    #                      choices=['OWNER', 'READER', 'NO ACCESS'])
     # cacl_parser.add_argument('users', metavar='user', help='Firecloud username',
     #                          nargs='+')
     # cacl_parser.set_defaults(func=meth_set_acl)

--- a/firecloud/tests/highlevel_tests.py
+++ b/firecloud/tests/highlevel_tests.py
@@ -63,7 +63,7 @@ class TestFISSHighLevel(unittest.TestCase):
         cls.workspace = getuser() + '_FISS_TEST'
 
         ret = call_func("space_exists", "-p", cls.project, "-w", cls.workspace)
-        if ret == True and os.environ.get("REUSE_SPACE", None):
+        if ret and os.environ.get("REUSE_SPACE", None):
             return
 
         print("\tCreating test workspace ...\n", file=sys.stderr)

--- a/firecloud/tests/lowlevel_tests.py
+++ b/firecloud/tests/lowlevel_tests.py
@@ -309,11 +309,10 @@ class TestFISSLowLevel(unittest.TestCase):
         print(r.status_code, r.content)
         self.assertEqual(r.status_code, 200)
 
-    @unittest.skip("Not Implemented")
     def test_list_workspace_configs(self):
-        """Test get_configs()."""
-        r =  fapi.get_configs(self.test_namespace,
-                                self.workspace)
+        """Test list_workspace_configs()."""
+        r =  fapi.list_workspace_configs(self.project,
+                                         self.workspace)
         print(r.status_code, r.content)
         self.assertEqual(r.status_code, 200)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class InstallCommand(install):
                              '').startswith('Google App Engine/') \
                and gcloud_default_path not in os.environ["PATH"].split(os.pathsep) \
                and which('gcloud') is None
-    
+
     sub_commands = install.sub_commands + [('install_gcloud', needs_gcloud)]
 
 class InstallGcloudCommand(Command):
@@ -41,9 +41,9 @@ class InstallGcloudCommand(Command):
         self.curl = None
         self.bash = None
         self.package_index = None
-        
+
     def finalize_options(self):
-        
+
         if platform.system() != "Windows":
             self.curl = which('curl')
             self.bash = which('bash')
@@ -54,7 +54,7 @@ class InstallGcloudCommand(Command):
             self.gcloud_url = "https://dl.google.com/dl/cloudsdk/channels/" \
                               "rapid/GoogleCloudSDKInstaller.exe"
         self.package_index = PackageIndex()
-    
+
     # Copied from setuptools.command.easy_install.easy_install
     @contextlib.contextmanager
     def _tmpdir(self):
@@ -80,7 +80,7 @@ class InstallGcloudCommand(Command):
                 except subprocess.CalledProcessError as cpe:
                     log.warn(u' '.join(cpe.cmd) + u":\n\t" +
                              cpe.output.decode('utf-8'))
-                
+
         elif self.curl is not None and self.bash is not None:
             try:
                 script = subprocess.check_output([self.curl, "-s", "-S",
@@ -107,7 +107,7 @@ class InstallGcloudCommand(Command):
 
     def get_inputs(self):
         return []
-    
+
     def get_outputs(self):
         return []
 
@@ -135,7 +135,7 @@ setup(
     },
     test_suite = 'nose.collector',
     install_requires = [
-        'google-auth==1.4.2',
+        'google-auth>=1.6.3',
         'pydot',
         'requests[security]',
         'setuptools>=40.3.0',


### PR DESCRIPTION
`api.py`:
* enabled namespace, name, and snapshot ID filtering for method repository listings
* new command `whoami` returns FireCloud user id

`fiss.py`: 
* updated listing calls (`method_list`, `config_list`) to enable new filters
* calls to listings updated to use filters when appropriate
* new command `set_config_acl` for setting ACLs on configs in the methods repo
* added capability to set method and config ACLs for groups
* `meth_list` and `meth_exists` commands updated to use argument `method` instead of `name` to be consistent with the rest of the CLI.
*  `config_list` updated to work on methods repo when user has a default workspace defined in their `~/.fissconfig`

`setup.py`:
* google-auth updated to use current release

`__init__.py`:
* Added warning filter to silence application default warning

`Makefile`:
* `publish` updated to use `twine`