### PR TITLE
v0.16.24

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,10 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.24 - Hotfix: corrected error in api.py due to difference in user ID
+           location when run from a Google Cloud VM; setup.py updated to
+           explicitly designate long_description_content_type as text/plain.
+
 v0.16.23 - LL: get_entities_tsv updated with ability to specify ordered
            attributes and data model, upload_entities and upload_entities_tsv
            updated to enable use of flexible data model API; HL: added back

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.23"
+__version__ = "0.16.24"

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -52,6 +52,8 @@ def _set_session():
             health()
             __USER_ID = id_token.verify_oauth2_token(__SESSION.credentials.id_token,
                                                      Request(session=__SESSION))['email']
+        except AttributeError:
+            __USER_ID = __SESSION.credentials.service_account_email
         except (DefaultCredentialsError, RefreshError) as gae:
             if os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/'):
                 raise


### PR DESCRIPTION
Hotfix
On Google Cloud VMs, the user's account email is stored in a different attribute of the `Session`'s `Credentials` object (`service_account_email` rather than `id_token`). The existence of the attributes are also mutually exclusive. This caused an `AttributeError` when accessing a non-existent attribute, and failure to populate `__USER_ID`, which broke several functions. Updated `api.py` to handle the different attribute locations.