### PR TITLE
allow create_submission without entity information

### DIFF
--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1034,7 +1034,7 @@ def list_submissions(namespace, workspace):
     return __get(uri)
 
 def create_submission(wnamespace, workspace, cnamespace, config,
-                      entity, etype, expression=None, use_callcache=True):
+                      entity=None, etype=None, expression=None, use_callcache=True):
     """Submit job in FireCloud workspace.
 
     Args:
@@ -1058,10 +1058,14 @@ def create_submission(wnamespace, workspace, cnamespace, config,
     body = {
         "methodConfigurationNamespace" : cnamespace,
         "methodConfigurationName" : config,
-         "entityType" : etype,
-         "entityName" : entity,
          "useCallCache" : use_callcache
     }
+
+    if etype:
+        body['entityType'] = etype
+
+    if entity:
+        body['entityName'] = entity
 
     if expression:
         body['expression'] = expression


### PR DESCRIPTION
this allows you to create a workflow submission using create_submission without including 'entityType' and 'entityName' inputs, which works in swagger, but currently in FISS those inputs are required and give an error when set to None.

More details:
I want to create a submission on a workflow that has inputs defined by paths, not by a data table. In swagger with https://api.firecloud.org/#!/Submissions/createSubmission I can simply omit the 'entityType' and 'entityName' fields of the submission json, like so:
{
  "methodConfigurationNamespace": "example-namespace-name",
  "methodConfigurationName": "example-config-name",
  "useCallCache": true
}
and it creates the submission correctly. 

but in FISS, you currently have to pass values for  'entityType' and 'entityName' to the create_submission function, and the json gets constructed like so:
{
  "methodConfigurationNamespace": "example-namespace-name",
  "methodConfigurationName": "example-config-name",
  "entityType": None,
  "entityName": None,
  "useCallCache": true
}
and that gives an error.

this PR allows you to pass entity=None and etype=None to create_submisison