### PR TITLE
v0.16.27

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,9 @@ Terms used below:  HL = high level interface, LL = low level interface
 
 v0.16.27 - HL: added new function validate_file_attrs, which takes all
            file attributes in a given workspace and entities contained within
-           and checks if they exist/the user has access to them.
+           and checks if they exist/the user has access to them; LL: Bugfix,
+           default root_url of API can now be set via CLI or interactively;
+           previously it could only be effectively modified via .fissconfig.
 
 v0.16.26 - LL: added copyFilesWithPrefix parameter to clone_workspace,
            create_submission no longer includes entity name and type in its

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,10 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.27 - HL: added new function validate_file_attrs, which takes all
+           file attributes in a given workspace and entities contained within
+           and checks if they exist/the user has access to them.
+
 v0.16.26 - LL: added copyFilesWithPrefix parameter to clone_workspace,
            create_submission no longer includes entity name and type in its
            payload when they are not set; HL: added copyFilesWithPrefix 

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.26"
+__version__ = "0.16.27"

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -91,7 +91,7 @@ def _fiss_agent_header(headers=None):
 def __get(methcall, headers=None, root_url=None, **kwargs):
     if not headers:
         headers = _fiss_agent_header()
-    if not root_url:
+    if root_url is None:
         root_url = fcconfig.root_url
     r = __SESSION.get(urljoin(root_url, methcall), headers=headers, **kwargs)
     if fcconfig.verbosity > 1:
@@ -101,7 +101,7 @@ def __get(methcall, headers=None, root_url=None, **kwargs):
 def __post(methcall, headers=None, root_url=None, **kwargs):
     if not headers:
         headers = _fiss_agent_header({"Content-type":  "application/json"})
-    if not root_url:
+    if root_url is None:
         root_url = fcconfig.root_url
     r = __SESSION.post(urljoin(root_url, methcall), headers=headers, **kwargs)
     if fcconfig.verbosity > 1:
@@ -115,7 +115,7 @@ def __post(methcall, headers=None, root_url=None, **kwargs):
 def __put(methcall, headers=None, root_url=None, **kwargs):
     if not headers:
         headers = _fiss_agent_header()
-    if not root_url:
+    if root_url is None:
         root_url = fcconfig.root_url
     r = __SESSION.put(urljoin(root_url, methcall), headers=headers, **kwargs)
     if fcconfig.verbosity > 1:
@@ -129,7 +129,7 @@ def __put(methcall, headers=None, root_url=None, **kwargs):
 def __delete(methcall, headers=None, root_url=None):
     if not headers:
         headers = _fiss_agent_header()
-    if not root_url:
+    if root_url is None:
         root_url = fcconfig.root_url
     r = __SESSION.delete(urljoin(root_url, methcall), headers=headers)
     if fcconfig.verbosity > 1:

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -88,17 +88,21 @@ def _fiss_agent_header(headers=None):
         fiss_headers.update(headers)
     return fiss_headers
 
-def __get(methcall, headers=None, root_url=fcconfig.root_url, **kwargs):
+def __get(methcall, headers=None, root_url=None, **kwargs):
     if not headers:
         headers = _fiss_agent_header()
+    if not root_url:
+        root_url = fcconfig.root_url
     r = __SESSION.get(urljoin(root_url, methcall), headers=headers, **kwargs)
     if fcconfig.verbosity > 1:
         print('FISSFC call: %s' % r.url, file=sys.stderr)
     return r
 
-def __post(methcall, headers=None, root_url=fcconfig.root_url, **kwargs):
+def __post(methcall, headers=None, root_url=None, **kwargs):
     if not headers:
         headers = _fiss_agent_header({"Content-type":  "application/json"})
+    if not root_url:
+        root_url = fcconfig.root_url
     r = __SESSION.post(urljoin(root_url, methcall), headers=headers, **kwargs)
     if fcconfig.verbosity > 1:
         info = r.url
@@ -108,9 +112,11 @@ def __post(methcall, headers=None, root_url=fcconfig.root_url, **kwargs):
         print('FISSFC call: POST %s' % info, file=sys.stderr)
     return r
 
-def __put(methcall, headers=None, root_url=fcconfig.root_url, **kwargs):
+def __put(methcall, headers=None, root_url=None, **kwargs):
     if not headers:
         headers = _fiss_agent_header()
+    if not root_url:
+        root_url = fcconfig.root_url
     r = __SESSION.put(urljoin(root_url, methcall), headers=headers, **kwargs)
     if fcconfig.verbosity > 1:
         info = r.url
@@ -120,9 +126,11 @@ def __put(methcall, headers=None, root_url=fcconfig.root_url, **kwargs):
         print('FISSFC call: PUT %s' % info, file=sys.stderr)
     return r
 
-def __delete(methcall, headers=None, root_url=fcconfig.root_url):
+def __delete(methcall, headers=None, root_url=None):
     if not headers:
         headers = _fiss_agent_header()
+    if not root_url:
+        root_url = fcconfig.root_url
     r = __SESSION.delete(urljoin(root_url, methcall), headers=headers)
     if fcconfig.verbosity > 1:
         print('FISSFC call: DELETE %s' % r.url, file=sys.stderr)


### PR DESCRIPTION
New function `validate_file_attrs`:
- Returns a list of any file (google bucket object) attributes that don't exist or the user does not have access to.

Bugfix (Fixes #138):
- While commands existed to modify the default root URL of the API, they only modified the calls to the API if set in the user's `.fissconfig`. This fix allows it to be set programmatically and via the CLI.