### PR TITLE
adding 'fields' parameter to list_workspaces() to match swagger API

### DIFF
--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1155,13 +1155,16 @@ def get_submission_queue():
 ### 1.7 Workspaces
 #####################
 
-def list_workspaces():
+def list_workspaces(fields=None):
     """Request list of FireCloud workspaces.
 
     Swagger:
         https://api.firecloud.org/#!/Workspaces/listWorkspaces
     """
-    return __get("workspaces")
+    if fields == None:
+        return __get("workspaces")
+    else:
+        return __get("workspaces", params={"fields": fields})
 
 def create_workspace(namespace, name, authorizationDomain="", attributes=None):
     """Create a new FireCloud Workspace.

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1158,10 +1158,16 @@ def get_submission_queue():
 def list_workspaces(fields=None):
     """Request list of FireCloud workspaces.
 
+    Args:
+        fields (str): a comma-delimited list of values that limits the
+            response payload to include only those keys and exclude other
+            keys (e.g., to include {"workspace": {"attributes": {...}}},
+            specify "workspace.attributes").
+
     Swagger:
         https://api.firecloud.org/#!/Workspaces/listWorkspaces
     """
-    if fields == None:
+    if fields is None:
         return __get("workspaces")
     else:
         return __get("workspaces", params={"fields": fields})

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -41,7 +41,7 @@ def fiss_cmd(function):
 def space_list(args):
     ''' List accessible workspaces, in TSV form: <namespace><TAB>workspace'''
 
-    r = fapi.list_workspaces()
+    r = fapi.list_workspaces(fields="workspace.name,workspace.namespace")
     fapi._check_response_code(r, 200)
 
     spaces = []
@@ -191,7 +191,7 @@ def space_set_acl(args):
 @fiss_cmd
 def space_search(args):
     """ Search for workspaces matching certain criteria """
-    r = fapi.list_workspaces()
+    r = fapi.list_workspaces(fields="workspace.name,workspace.namespace,workspace.bucketName")
     fapi._check_response_code(r, 200)
 
     # Parse the JSON for workspace + namespace; then filter by


### PR DESCRIPTION
Hello,

the [firecloud.api.list_workspaces() function](https://github.com/broadinstitute/fiss/blob/7cb3f1254721907dd339cd5bde616860a56c238f/firecloud/api.py#L1158) maps to the [listWorkspaces](https://api.firecloud.org/#/Workspaces/listWorkspaces) API endpoint, but does not offer the ability to restrict the results by field, often causing lots of extraneous data to be transferred. this PR adds this capability, preserving the semantics of field specification ( e.g., { "A": {"B": "C"} } -> "A.B.C" ).

current output:
```
>>> fapi.list_workspaces(fields="workspace.name")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: list_workspaces() got an unexpected keyword argument 'fields'
```
...or
```
fapi.list_workspaces()
[{'accessLevel': 'READER', 'public': True, 'workspace': {'attributes': {'library:requiresExternalApproval': False, 'library:dulvn': 4, 'library:studyDesign': 'Tumor/Normal', 'library:cohortCountry': 'USA', 'description': 'TCGA Acute Myeloid Leukemia Open-Access Data Workspace\n\n*hg38 TCGA and TARGET workspaces reference files by their GDC UUIDs.  In order to run analyses on the referenced data files, you will need to run workflows that retrieve the files from the GDC and copy them to your workspace bucket.  See   [this forum post](https://gatkforums.broadinstitute.org/firecloud/discussion/10382/populating-hg38-tcga-and-target-workspaces-with-data-files#latest) for instructions on the running of these workflows.*', 'workspace-column-defaults': '{"participant": {"shown": ["submitter_id", "project_id", "participant_id"]}, "sample":{"shown":["submitter_id", "sample_id", "participant", "sample_type"]}, "pair":{"shown":["tumor_submitter_id", "normal_submitter_id", "pair_id"]}}', 'library:published': True, 'library:indication': 'Acute Myeloid Leukemia', 'library:contactEmail': 'rfrazer@broadinstitute.org', 'library:numSubjects': 200, 'library:datasetOwner': 'NCI', 'library:datatype': {'itemsType': 'AttributeValue', 'items': ['Whole Exome', 'Genotyping Array', 'RNA-Seq', 'miRNA-Seq', 'Methylation Array', 'Protein Expression Array']}, 'library:primaryDiseaseSite': 'Bone Marrow', 'library:datasetCustodian': 'dbGAP', 'library:projectName': 'TCGA', 'library:cellType': 'Primary tumor cell, Whole blood', 'library:institute': {'itemsType': 'AttributeValue', 'items': ['NCI']}, 'library:orsp': 'TODO', 'legacy_flag': 'false', 'library:dataUseRestriction': 'General Research Use', 'library:datasetDepositor': 'Ruslana Frazer', 'library:reference': 'GRCh38/hg38', 'library:datasetVersion': 'GDCDR-12-0', 'library:datasetName': 'TCGA_LAML_hg38_OpenAccess', 'library:dataCategory': {'itemsType': 'AttributeValue', 'items': ['Simple Nucleotide Variation', 'Copy Number Variation', 'Expression Quantification', 'DNA-Methylation', 'Clinical phenotypes', 'Biosample metadata']}, 'library:dataFileFormats': {'itemsType': 'AttributeValue', 'items': ['TXT', 'MAF', 'TSV', 'BCR XML']}, 'library:useLimitationOption': 'skip', 'library:datasetDescription': "This cohort is part of The Cancer Genome Atlas project (https://cancergenome.nih.gov/abouttcga/overview).  This cohort includes raw data and analysis of cancer patients samples by genomic DNA copy number arrays, DNA methylation, exome sequencing, mRNA arrays, microRNA sequencing and reverse phase protein arrays. De-identified patients' clinical phenotypes and metadata are also included. For more information see the full TCGA cohorts publication list at: https://cancergenome.nih.gov/publications; Data description is also summarized at : https://TCGA_data.nci.nih.gov/docs/publications//tcga/datatype.html"}, 'authorizationDomain': [], 'bucketName': 'fc-00287834-dea8-4f68-8dd4-df0cc83cc9c8', 'createdBy': 'birger@broadinstitute.org', 'createdDate': '2018-08-02T16:15:52.630Z', 'isLocked': False, 'lastModified': '2018-08-24T19:10:44.418Z', 'name': 'TCGA_LAML_hg38_OpenAccess_GDCDR-12-0_DATA', 'namespace': 'broad-firecloud-tcga', 'workflowCollectionName': '00287834-dea8-4f68-8dd4-df0cc83cc9c8', 'workspaceId': '00287834-dea8-4f68-8dd4-df0cc83cc9c8'}, 'workspaceSubmissionStats': {'runningSubmissionsCount': 0}}, ( ... many more ...) ]
```


PR output:
```
>>> fapi.list_workspaces(fields="workspace.name").json()
[{'workspace': {'name': 'TCGA_LAML_hg38_OpenAccess_GDCDR-12-0_DATA'}}, ... ]
```

thanks for reading, please let me know if there are ways to improve this and future submissions!