### PR TITLE
adding fields parameter to get_workspace()

### DIFF
--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1219,18 +1219,25 @@ def delete_workspace(namespace, workspace):
     uri = "workspaces/{0}/{1}".format(namespace, workspace)
     return __delete(uri)
 
-def get_workspace(namespace, workspace):
+def get_workspace(namespace, workspace, fields=None):
     """Request FireCloud Workspace information.
 
     Args:
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
+        fields (str): a comma-delimited list of values that limits the
+            response payload to include only those keys and exclude other
+            keys (e.g., to include {"workspace": {"attributes": {...}}},
+            specify "workspace.attributes").
 
     Swagger:
         https://api.firecloud.org/#!/Workspaces/getWorkspace
     """
     uri = "workspaces/{0}/{1}".format(namespace, workspace)
-    return __get(uri)
+    if fields is None:
+        return __get(uri)
+    else:
+        return __get(uri, params={"fields": fields})
 
 def get_workspace_acl(namespace, workspace):
     """Request FireCloud access aontrol list for workspace.

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1155,13 +1155,16 @@ def get_submission_queue():
 ### 1.7 Workspaces
 #####################
 
-def list_workspaces():
+def list_workspaces(fields=None):
     """Request list of FireCloud workspaces.
 
     Swagger:
         https://api.firecloud.org/#!/Workspaces/listWorkspaces
     """
-    return __get("workspaces")
+    if fields == None:
+        return __get("workspaces")
+    else:
+        return __get("workspaces", params={"fields": fields})
 
 def create_workspace(namespace, name, authorizationDomain="", attributes=None):
     """Create a new FireCloud Workspace.

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1158,10 +1158,16 @@ def get_submission_queue():
 def list_workspaces(fields=None):
     """Request list of FireCloud workspaces.
 
+    Args:
+        fields (str): a comma-delimited list of values that limits the
+            response payload to include only those keys and exclude other
+            keys (e.g., to include {"workspace": {"attributes": {...}}},
+            specify "workspace.attributes").
+
     Swagger:
         https://api.firecloud.org/#!/Workspaces/listWorkspaces
     """
-    if fields == None:
+    if fields is None:
         return __get("workspaces")
     else:
         return __get("workspaces", params={"fields": fields})

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -68,7 +68,7 @@ def space_exists(args):
     #      ...
     #   fi
     try:
-        r = fapi.get_workspace(args.project, args.workspace)
+        r = fapi.get_workspace(args.project, args.workspace, fields="workspace.name")
         fapi._check_response_code(r, 200)
         exists = True
     except FireCloudServerError as e:
@@ -873,7 +873,7 @@ def attr_get(args):
         for k in ["samples", "participants", "pairs"]:
             attrs.pop(k, None)
     else:
-        r = fapi.get_workspace(args.project, args.workspace)
+        r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         attrs = r.json()['workspace']['attributes']
 
@@ -1047,7 +1047,7 @@ def attr_copy(args):
         return 1
 
     # First get the workspace attributes of the source workspace
-    r = fapi.get_workspace(args.project, args.workspace)
+    r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
     fapi._check_response_code(r, 200)
 
     # Parse the attributes
@@ -1206,7 +1206,8 @@ def mop(args):
     # First retrieve the workspace to get bucket information
     if args.verbose:
         print("Retrieving workspace information...")
-    r = fapi.get_workspace(args.project, args.workspace)
+    fields = "workspace.bucketName,workspace.name,workspace.attributes"
+    r = fapi.get_workspace(args.project, args.workspace, fields=fields)
     fapi._check_response_code(r, 200)
     workspace = r.json()
     bucket = workspace['workspace']['bucketName']
@@ -1405,7 +1406,7 @@ def validate_file_attrs(args):
     verbose = fcconfig.verbosity
     if verbose:
         eprint("Retrieving workspace information...")
-    r = fapi.get_workspace(args.project, args.workspace)
+    r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
     fapi._check_response_code(r, 200)
     workspace = r.json()
 
@@ -1622,7 +1623,7 @@ def config_validate(args):
             entity_d = entity_r.json()
 
     # also get the workspace info
-    w = fapi.get_workspace(args.project, args.workspace)
+    w = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
     fapi._check_response_code(w, 200)
     workspace_d = w.json()
 

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -41,7 +41,7 @@ def fiss_cmd(function):
 def space_list(args):
     ''' List accessible workspaces, in TSV form: <namespace><TAB>workspace'''
 
-    r = fapi.list_workspaces()
+    r = fapi.list_workspaces(fields="workspace.name,workspace.namespace")
     fapi._check_response_code(r, 200)
 
     spaces = []
@@ -191,7 +191,7 @@ def space_set_acl(args):
 @fiss_cmd
 def space_search(args):
     """ Search for workspaces matching certain criteria """
-    r = fapi.list_workspaces()
+    r = fapi.list_workspaces(fields="workspace.name,workspace.namespace,workspace.bucketName")
     fapi._check_response_code(r, 200)
 
     # Parse the JSON for workspace + namespace; then filter by


### PR DESCRIPTION
Hello,

much like PR #143, this adds the fields parameter to get_workspace(), allowing firecloud to return selected-for data instead of a JSON dump of all info. i have tested the API call, and have added fields to calls in fiss.py where i thought they could be useful; some of the commands are unfamiliar to me, so I am not entirely sure my implementation was perfect. examples:

- for the `mop` command, i get the error:
```
Error retrieving files from bucket:
	Command '['gsutil', 'ls', '-l', 'gs://fc-secure-REDACTED/**']' returned non-zero exit status 1.
	b'CommandException: One or more URLs matched no objects.\n'
```

- for the `config_validate` command, i get the error:
```
Error 404 (rawls): None/None does not exist in Workspace(...)
```
... where the '...' is a bunch of workspace metadata.

in the case of both of these, i also get the same error with the fissfc command from rc-0.16.28, so my guess is the error is unrelated to the changes, but i wanted to inform any reviewers who might see something amiss.

thanks for reading, please let me know how i can improve the quality of the submission.

- luke
[ shameless ping for attention: @dheiman  ;) ]