### PR TITLE
v0.16.29

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,13 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.29 - LL: added fields parameter to get_workspace; HL: space_exists,
+           attr_get, attr_copy, mop, validate_file_attrs, and config_validate
+           updated to use fields parameter in call to get_workspace; py3 fixes:
+           easy_install removed from setup.py to enable compatibility with
+           latest setuptools, tempfile generated in fccore.edit_text now opens
+           in mode 'w' instead of 'w+b' to work with both py2 and py3 str.
+
 v0.16.28 - LL: added fields parameter to list_workspaces; HL: space_list and
            space_search updated to use fields parameter in call to
            list_workspaces, proj_list fixed to enable py3 compatibility. 

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.28"
+__version__ = "0.16.29"

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1219,18 +1219,25 @@ def delete_workspace(namespace, workspace):
     uri = "workspaces/{0}/{1}".format(namespace, workspace)
     return __delete(uri)
 
-def get_workspace(namespace, workspace):
+def get_workspace(namespace, workspace, fields=None):
     """Request FireCloud Workspace information.
 
     Args:
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
+        fields (str): a comma-delimited list of values that limits the
+            response payload to include only those keys and exclude other
+            keys (e.g., to include {"workspace": {"attributes": {...}}},
+            specify "workspace.attributes").
 
     Swagger:
         https://api.firecloud.org/#!/Workspaces/getWorkspace
     """
     uri = "workspaces/{0}/{1}".format(namespace, workspace)
-    return __get(uri)
+    if fields is None:
+        return __get(uri)
+    else:
+        return __get(uri, params={"fields": fields})
 
 def get_workspace_acl(namespace, workspace):
     """Request FireCloud access aontrol list for workspace.

--- a/firecloud/fccore.py
+++ b/firecloud/fccore.py
@@ -189,7 +189,7 @@ __EDITOR__ = os.environ.get('EDITOR','vi')
 
 def edit_text(text=None):
     # Edit block of text in a single string, returning the edited result
-    tf = tempfile.NamedTemporaryFile(suffix=".tmp")
+    tf = tempfile.NamedTemporaryFile(suffix=".tmp", mode='w')
     if text:
         tf.write(text)
         tf.flush()

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -68,7 +68,7 @@ def space_exists(args):
     #      ...
     #   fi
     try:
-        r = fapi.get_workspace(args.project, args.workspace)
+        r = fapi.get_workspace(args.project, args.workspace, fields="workspace.name")
         fapi._check_response_code(r, 200)
         exists = True
     except FireCloudServerError as e:
@@ -873,7 +873,7 @@ def attr_get(args):
         for k in ["samples", "participants", "pairs"]:
             attrs.pop(k, None)
     else:
-        r = fapi.get_workspace(args.project, args.workspace)
+        r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         attrs = r.json()['workspace']['attributes']
 
@@ -1047,7 +1047,7 @@ def attr_copy(args):
         return 1
 
     # First get the workspace attributes of the source workspace
-    r = fapi.get_workspace(args.project, args.workspace)
+    r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
     fapi._check_response_code(r, 200)
 
     # Parse the attributes
@@ -1206,7 +1206,8 @@ def mop(args):
     # First retrieve the workspace to get bucket information
     if args.verbose:
         print("Retrieving workspace information...")
-    r = fapi.get_workspace(args.project, args.workspace)
+    fields = "workspace.bucketName,workspace.name,workspace.attributes"
+    r = fapi.get_workspace(args.project, args.workspace, fields=fields)
     fapi._check_response_code(r, 200)
     workspace = r.json()
     bucket = workspace['workspace']['bucketName']
@@ -1405,7 +1406,7 @@ def validate_file_attrs(args):
     verbose = fcconfig.verbosity
     if verbose:
         eprint("Retrieving workspace information...")
-    r = fapi.get_workspace(args.project, args.workspace)
+    r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
     fapi._check_response_code(r, 200)
     workspace = r.json()
 
@@ -1622,7 +1623,7 @@ def config_validate(args):
             entity_d = entity_r.json()
 
     # also get the workspace info
-    w = fapi.get_workspace(args.project, args.workspace)
+    w = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
     fapi._check_response_code(w, 200)
     workspace_d = w.json()
 

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
         'google-auth>=1.6.3',
         'pydot',
         'requests[security]',
-        'setuptools>=40.3.0, <=50.0.0',
+        'setuptools>=40.3.0',
         'six',
         'nose',
         'pylint==1.7.2'

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,22 @@
 import os
+import sys
 import platform
 import contextlib
 import tempfile
 import subprocess
+from distutils import log
+from shutil import rmtree
 from setuptools import setup, find_packages, Command
 from setuptools.command.install import install
 from setuptools.package_index import PackageIndex
-from setuptools.command.easy_install import six, rmtree_safe, rmtree, log
 from firecloud.__about__ import __version__
 from firecloud import which
 _README           = os.path.join(os.path.dirname(__file__), 'README')
 _LONG_DESCRIPTION = open(_README).read()
+
+# Workaround for http://bugs.python.org/issue24672
+linux_py2_ascii = platform.system() == 'Linux' and sys.version_info.major == 2
+rmtree_safe = str if linux_py2_ascii else lambda x: x
 
 class InstallCommand(install):
     def needs_gcloud(self):
@@ -58,7 +64,7 @@ class InstallGcloudCommand(Command):
     # Copied from setuptools.command.easy_install.easy_install
     @contextlib.contextmanager
     def _tmpdir(self):
-        tmpdir = tempfile.mkdtemp(prefix=six.u("install_gcloud-"))
+        tmpdir = tempfile.mkdtemp(prefix="install_gcloud-".encode('utf-8').decode('utf-8'))
         try:
             # cast to str as workaround for #709 and #710 and #712
             yield str(tmpdir)
@@ -139,7 +145,7 @@ setup(
         'google-auth>=1.6.3',
         'pydot',
         'requests[security]',
-        'setuptools>=40.3.0',
+        'setuptools>=40.3.0, <=50.0.0',
         'six',
         'nose',
         'pylint==1.7.2'


### PR DESCRIPTION
Fixes #147

`api.py`:
* added `fields` parameter to `get_workspace()`

`fiss.py`:
* `space_exists()`, `attr_get()`, `attr_copy()`, `mop()`, `validate_file_attrs()`, and `config_validate()` updated to use `fields` parameter in call to `get_workspace()`

py3 compatibility bugfixes:
* `setup.py`:
   - `easy_install` removed to enable compatibility with latest `setuptools`
* `fccore.py`:
   - tempfile generated in `edit_text()` now opens in mode `'w'` instead of `'w+b'` to work with both py2 and py3 `str` objects.