### PR TITLE
[DFE-299] fissfc attr_list - update behavior for getting workspace attributes

### DIFF
--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -864,15 +864,15 @@ def attr_get(args):
             fapi._check_response_code(r, 200)
             ws_attrs = r.json()['workspace']['attributes']
             # check for referenceData in workspace
-            attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_')}
-            if not attrs:
+            ref_attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_')}
+            if not ref_attrs:
                 print("There are no reference data available in workspace. Load a reference and try again.")
                 return 1
-            else:
-                attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_{}'.format(args.entity))}
-                if not attrs:           # if chosen referenceData is not in workspace
-                    ref_options = [(attr.split('_')[1]) for attr in ws_attrs if attr.startswith('referenceData_')]
-                    print("The given reference is not in workspace. Try another available option: {}".format(set(ref_options)))
+            attrs = {attr:ref_attrs[attr] for attr in ref_attrs if attr.startswith('referenceData_{}'.format(args.entity))}
+            if not attrs:           # if chosen referenceData is not in workspace
+                ref_options = sorted({attr.split('_')[1] for attr in ref_attrs})
+                print("The given reference is not in workspace. Available option(s): {}.".format(", ".join(ref_options))
+                return 1
 
         else:                           # return named entity attrs
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -865,8 +865,8 @@ def attr_get(args):
             all_attrs = r.json()['workspace']['attributes']
             attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
             if not attrs:
-                print(f"The given reference, {args.entity},is not in workspace. Try another option: hg38 or b37")
-        else:                               # return named entity attributes
+                print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
+        else:                           # return named entity attributes
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)
             attrs = r.json()['attributes']
@@ -883,11 +883,15 @@ def attr_get(args):
             # (but later may provide a way for users to request such, if wanted)
             for k in ["samples", "participants", "pairs"]:
                 attrs.pop(k, None)
-    else:                       # return only workspace attrs (no referenceData)
+    elif args.ws_attrs:                 # return workspace attrs (no referenceData)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         all_attrs = r.json()['workspace']['attributes']
         attrs = {k:all_attrs[k] for k in all_attrs if not re.search('referenceData', k)}
+    else:                               # return all attributes (workspace + referenceData)
+        r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
+        fapi._check_response_code(r, 200)
+        attrs = r.json()['workspace']['attributes']
 
     if args.attributes:         # return a subset of attributes, if requested
         attrs = {k:attrs[k] for k in set(attrs).intersection(args.attributes)}
@@ -2534,6 +2538,8 @@ def main(argv=None):
     subp.add_argument('-t', '--entity-type', choices=etype_choices,
                       required=etype_required, default=fcconfig.entity_type,
                       help=etype_help)
+    subp.add_argument('-a', '--ws_attrs', action='store_true',
+                      help="Argument retrieves workspace attributes (no referenceData attributes).")
     subp.set_defaults(func=attr_list)
 
     # Copy attributes

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -864,6 +864,8 @@ def attr_get(args):
             fapi._check_response_code(r, 200)
             all_attrs = r.json()['workspace']['attributes']
             attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
+            if not attrs:
+                print(f"The given reference, {args.entity},is not in workspace. Try another option: hg38 or b37")
         else:                               # return named entity attributes
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)
@@ -2528,7 +2530,7 @@ def main(argv=None):
                     'If no entity Type+Name is given, workspace-level ' +
                     'attributes will be listed.')
     # FIXME: this should explain that default entity is workspace
-    subp.add_argument('-e', '--entity', help="Entity name")
+    subp.add_argument('-e', '--entity', help="Entity name. For referenceData: hg38 or b37")
     subp.add_argument('-t', '--entity-type', choices=etype_choices,
                       required=etype_required, default=fcconfig.entity_type,
                       help=etype_help)

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -866,7 +866,7 @@ def attr_get(args):
             attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
             if not attrs:
                 print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
-        else:                           # return named entity attributes
+        else:                           # return named entity attrs
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)
             attrs = r.json()['attributes']
@@ -883,12 +883,12 @@ def attr_get(args):
             # (but later may provide a way for users to request such, if wanted)
             for k in ["samples", "participants", "pairs"]:
                 attrs.pop(k, None)
-    elif args.ws_attrs:                 # return workspace attrs (no referenceData)
+    elif args.ws_attrs:                 # return all workspace attrs (no referenceData attrs)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         all_attrs = r.json()['workspace']['attributes']
         attrs = {k:all_attrs[k] for k in all_attrs if not re.search('referenceData', k)}
-    else:                               # return all attributes (workspace + referenceData)
+    else:                               # return all attributes (workspace + referenceData attrs)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         attrs = r.json()['workspace']['attributes']

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -863,9 +863,15 @@ def attr_get(args):
             r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
             fapi._check_response_code(r, 200)
             all_attrs = r.json()['workspace']['attributes']
-            attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
+            # check for referenceData (b37 or hg38) in workspace
+            attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_', k)}
             if not attrs:
-                print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
+                print(f"There are no reference data available in workspace. Load a reference and try again: hg38 or b37")
+            else:
+                attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
+                # if the chosen referenceData is not in workspace
+                if not attrs:
+                    print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
         else:                           # return named entity attrs
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)


### PR DESCRIPTION
Current behavior (default) for the command:
`fissfc attr_list -w workspace -p project` returns all the workspace attributes which includes the referenceData (hg38 or b37)

New behavior for the command:
`fissfc attr_list -w workspace -p project -e entity -t entity_type` allows user to submit "hg38"/"b37" as options for `-e` and `ref` as `-t` to get back referenceData for either reference genome build and also MAINTAINS original default behavior if user wants to pass in specific name of entity to retrieve entity attributes.

`fissfc attr_list -w workspace -p project -a` allows user to retrieve only workspace attributes - does not return referenceData.
