### PR TITLE
v0.16.31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.15-slim
+FROM python:3.8.5-slim
 
 COPY . /fiss
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,8 @@ Terms used below:  HL = high level interface, LL = low level interface
 
 v0.16.31 - Changed Dockerfile base image to python 3; HL: mop updated to
            find files in attributes with array and compound data structure
-           values, attr_delete updated to work on pair attributes.
+           values, attr_delete updated to work on pair attributes, attr_get and
+           attr_list updated to return or elide reference data in workspace.
 
 v0.16.30 - HL: hotfix - re-enabled making methods public.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,9 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
-v0.16.31 - Changed Dockerfile base image to python 3.
+v0.16.31 - Changed Dockerfile base image to python 3; HL: mop updated to
+           find files in attributes with array and compound data structure
+           values.
 
 v0.16.30 - HL: hotfix - re-enabled making methods public.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,8 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
-v0.16.31 - Changed Dockerfile base image to python 3; HL: mop updated to
+v0.16.31 - Changed Dockerfile base image to python 3; suppress Python 2
+           deprecation warning from cryptography module; HL: mop updated to
            find files in attributes with array and compound data structure
            values, attr_delete updated to work on pair attributes, attr_get and
            attr_list updated to return or elide reference data in workspace.

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@ Terms used below:  HL = high level interface, LL = low level interface
 
 v0.16.31 - Changed Dockerfile base image to python 3; HL: mop updated to
            find files in attributes with array and compound data structure
-           values.
+           values, attr_delete updated to work on pair attributes.
 
 v0.16.30 - HL: hotfix - re-enabled making methods public.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.31 - Changed Dockerfile base image to python 3.
+
 v0.16.30 - HL: hotfix - re-enabled making methods public.
 
 v0.16.29 - LL: added fields parameter to get_workspace; HL: space_exists,

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.30"
+__version__ = "0.16.31"

--- a/firecloud/__init__.py
+++ b/firecloud/__init__.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 warnings.filterwarnings('ignore', 'Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/')
-
+warnings.filterwarnings('ignore', 'Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.')
 
 # Based on https://stackoverflow.com/a/379535
 def which(program):

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -864,15 +864,15 @@ def attr_get(args):
             fapi._check_response_code(r, 200)
             ws_attrs = r.json()['workspace']['attributes']
             # check for referenceData in workspace
-            attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_')}
-            if not attrs:
+            ref_attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_')}
+            if not ref_attrs:
                 print("There are no reference data available in workspace. Load a reference and try again.")
                 return 1
-            else:
-                attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_{}'.format(args.entity))}
-                if not attrs:           # if chosen referenceData is not in workspace
-                    ref_options = [(attr.split('_')[1]) for attr in ws_attrs if attr.startswith('referenceData_')]
-                    print("The given reference is not in workspace. Try another available option: {}".format(set(ref_options)))
+            attrs = {attr:ref_attrs[attr] for attr in ref_attrs if attr.startswith('referenceData_{}'.format(args.entity))}
+            if not attrs:           # if chosen referenceData is not in workspace
+                ref_options = sorted({attr.split('_')[1] for attr in ref_attrs})
+                print("The given reference is not in workspace. Available option(s): {}.".format(", ".join(ref_options))
+                return 1
 
         else:                           # return named entity attrs
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -864,6 +864,8 @@ def attr_get(args):
             fapi._check_response_code(r, 200)
             all_attrs = r.json()['workspace']['attributes']
             attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
+            if not attrs:
+                print(f"The given reference, {args.entity},is not in workspace. Try another option: hg38 or b37")
         else:                               # return named entity attributes
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)
@@ -2547,7 +2549,7 @@ def main(argv=None):
                     'If no entity Type+Name is given, workspace-level ' +
                     'attributes will be listed.')
     # FIXME: this should explain that default entity is workspace
-    subp.add_argument('-e', '--entity', help="Entity name")
+    subp.add_argument('-e', '--entity', help="Entity name. For referenceData: hg38 or b37")
     subp.add_argument('-t', '--entity-type', choices=etype_choices,
                       required=etype_required, default=fcconfig.entity_type,
                       help=etype_help)

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -979,9 +979,12 @@ def attr_delete(args):
             name = entity_dict['name']
             line = name
             # TODO: Fix other types?
-            if etype == "sample":
+            if etype in ("sample", "pair"):
                 line += "\t" + entity_dict['attributes']['participant']['entityName']
-            for attr in attrs:
+            if etype == "pair":
+                line += "\t" + entity_dict['attributes']['case_sample']['entityName']
+                line += "\t" + entity_dict['attributes']['control_sample']['entityName']
+            for _ in attrs:
                 line += "\t__DELETE__"
             # Improve performance by only updating records that have changed
             entity_data.append(line)
@@ -989,6 +992,8 @@ def attr_delete(args):
         entity_header = ["entity:" + etype + "_id"]
         if etype == "sample":
             entity_header.append("participant_id")
+        if etype == "pair":
+            entity_header += ["participant", "case_sample", "control_sample"]
         entity_header = '\t'.join(entity_header + list(attrs))
 
         # Remove attributes from an entity

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -859,19 +859,21 @@ def attr_get(args):
     a special __header__ entry is optionally added to the result. '''
 
     if args.entity_type and args.entity:
-        if args.entity_type == "ref":       # return referenceData (b37 or hg38) attributes
+        if args.entity_type == "ref":       # return referenceData attributes
             r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
             fapi._check_response_code(r, 200)
-            all_attrs = r.json()['workspace']['attributes']
-            # check for referenceData (b37 or hg38) in workspace
-            attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_', k)}
+            ws_attrs = r.json()['workspace']['attributes']
+            # check for referenceData in workspace
+            attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_')}
             if not attrs:
-                print(f"There are no reference data available in workspace. Load a reference and try again: hg38 or b37")
+                print("There are no reference data available in workspace. Load a reference and try again.")
+                return 1
             else:
-                attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
-                # if the chosen referenceData is not in workspace
-                if not attrs:
-                    print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
+                attrs = {attr:ws_attrs[attr] for attr in ws_attrs if attr.startswith('referenceData_{}'.format(args.entity))}
+                if not attrs:           # if chosen referenceData is not in workspace
+                    ref_options = [(attr.split('_')[1]) for attr in ws_attrs if attr.startswith('referenceData_')]
+                    print("The given reference is not in workspace. Try another available option: {}".format(set(ref_options)))
+
         else:                           # return named entity attrs
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)
@@ -892,8 +894,8 @@ def attr_get(args):
     elif args.ws_attrs:                 # return all workspace attrs (no referenceData attrs)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
-        all_attrs = r.json()['workspace']['attributes']
-        attrs = {k:all_attrs[k] for k in all_attrs if not re.search('referenceData', k)}
+        ws_attrs = r.json()['workspace']['attributes']
+        attrs = {attr:ws_attrs[attr] for attr in ws_attrs if not attr.startswith('referenceData')}
     else:                               # return all attributes (workspace + referenceData attrs)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
@@ -916,7 +918,7 @@ def attr_get(args):
             object_id = u'entity:%s_id' % args.entity_type
             result['__header__'] = [object_id] + list(attrs.keys())
         else:
-            result = attrs                  # Workspace attributes (no referenceData attributes)
+            result = attrs                  # Workspace attributes
     else:
         result = {}
 
@@ -2559,7 +2561,7 @@ def main(argv=None):
                     'If no entity Type+Name is given, workspace-level ' +
                     'attributes will be listed.')
     # FIXME: this should explain that default entity is workspace
-    subp.add_argument('-e', '--entity', help="Entity name. For referenceData: hg38 or b37")
+    subp.add_argument('-e', '--entity', help="Entity name or referenceData name.")
     subp.add_argument('-t', '--entity-type', choices=etype_choices,
                       required=etype_required, default=fcconfig.entity_type,
                       help=etype_help)

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -866,7 +866,7 @@ def attr_get(args):
             attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
             if not attrs:
                 print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
-        else:                           # return named entity attributes
+        else:                           # return named entity attrs
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)
             attrs = r.json()['attributes']
@@ -883,12 +883,12 @@ def attr_get(args):
             # (but later may provide a way for users to request such, if wanted)
             for k in ["samples", "participants", "pairs"]:
                 attrs.pop(k, None)
-    elif args.ws_attrs:                 # return workspace attrs (no referenceData)
+    elif args.ws_attrs:                 # return all workspace attrs (no referenceData attrs)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         all_attrs = r.json()['workspace']['attributes']
         attrs = {k:all_attrs[k] for k in all_attrs if not re.search('referenceData', k)}
-    else:                               # return all attributes (workspace + referenceData)
+    else:                               # return all attributes (workspace + referenceData attrs)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         attrs = r.json()['workspace']['attributes']

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -859,26 +859,33 @@ def attr_get(args):
     a special __header__ entry is optionally added to the result. '''
 
     if args.entity_type and args.entity:
-        r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
-        fapi._check_response_code(r, 200)
-        attrs = r.json()['attributes']
-        # It is wrong for the members of container objects to appear as metadata
-        # (attributes) attached to the container, as it conflates fundamentally
-        # different things: annotation vs membership. This can be seen by using
-        # a suitcase model of reasoning: ATTRIBUTES are METADATA like the weight
-        # & height of the suitcase, the shipping label and all of its passport
-        # stamps; while MEMBERS are the actual CONTENTS INSIDE the suitcase.
-        # This conflation also contradicts the design & docs (which make a clear
-        # distinction between MEMBERSHIP and UPDATE loadfiles).  For this reason
-        # a change has been requested of the FireCloud dev team (via forum), and
-        # until it is implemented we will elide "list of members" attributes here
-        # (but later may provide a way for users to request such, if wanted)
-        for k in ["samples", "participants", "pairs"]:
-            attrs.pop(k, None)
-    else:
+        if args.entity_type == "ref":       # return referenceData (b37 or hg38) attributes
+            r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
+            fapi._check_response_code(r, 200)
+            all_attrs = r.json()['workspace']['attributes']
+            attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
+        else:                               # return named entity attributes
+            r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
+            fapi._check_response_code(r, 200)
+            attrs = r.json()['attributes']
+            # It is wrong for the members of container objects to appear as metadata
+            # (attributes) attached to the container, as it conflates fundamentally
+            # different things: annotation vs membership. This can be seen by using
+            # a suitcase model of reasoning: ATTRIBUTES are METADATA like the weight
+            # & height of the suitcase, the shipping label and all of its passport
+            # stamps; while MEMBERS are the actual CONTENTS INSIDE the suitcase.
+            # This conflation also contradicts the design & docs (which make a clear
+            # distinction between MEMBERSHIP and UPDATE loadfiles).  For this reason
+            # a change has been requested of the FireCloud dev team (via forum), and
+            # until it is implemented we will elide "list of members" attributes here
+            # (but later may provide a way for users to request such, if wanted)
+            for k in ["samples", "participants", "pairs"]:
+                attrs.pop(k, None)
+    else:                       # return only workspace attrs (no referenceData)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
-        attrs = r.json()['workspace']['attributes']
+        all_attrs = r.json()['workspace']['attributes']
+        attrs = {k:all_attrs[k] for k in all_attrs if not re.search('referenceData', k)}
 
     if args.attributes:         # return a subset of attributes, if requested
         attrs = {k:attrs[k] for k in set(attrs).intersection(args.attributes)}
@@ -897,7 +904,7 @@ def attr_get(args):
             object_id = u'entity:%s_id' % args.entity_type
             result['__header__'] = [object_id] + list(attrs.keys())
         else:
-            result = attrs                  # Workspace attributes
+            result = attrs                  # Workspace attributes (no referenceData attributes)
     else:
         result = {}
 
@@ -2050,7 +2057,7 @@ def main(argv=None):
     workspace_required = not bool(fcconfig.workspace)
     etype_required = not bool(fcconfig.entity_type)
     etype_choices = ['participant', 'participant_set', 'sample', 'sample_set',
-                     'pair', 'pair_set' ]
+                     'pair', 'pair_set', 'ref']
 
     # Initialize core parser (TODO: Add longer description)
     usage  = 'fissfc [OPTIONS] [CMD [-h | arg ...]]'

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -1223,12 +1223,12 @@ def mop(args):
     # Handle Basic Values, Compound data structures, and Nestings thereof
     def update_referenced_files(referenced_files, attrs, bucket_prefix):
         for attr in attrs:
-            # Compound data structures resolve to dicts
-            if isinstance(attr, dict) and 'itemsType' not in attr:
-                update_referenced_files(referenced_files, attr.values(), bucket_prefix)
             # 1-D array attributes are dicts with the values stored in 'items'
-            elif isinstance(attr, dict) and attr['itemsType'] == 'AttributeValue':
+            if isinstance(attr, dict) and attr.get('itemsType') == 'AttributeValue':
                 update_referenced_files(referenced_files, attr['items'], bucket_prefix)
+            # Compound data structures resolve to dicts
+            elif isinstance(attr, dict):
+                update_referenced_files(referenced_files, attr.values(), bucket_prefix)
             # Nested arrays resolve to lists
             elif isinstance(attr, list):
                 update_referenced_files(referenced_files, attr, bucket_prefix)

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -865,8 +865,8 @@ def attr_get(args):
             all_attrs = r.json()['workspace']['attributes']
             attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
             if not attrs:
-                print(f"The given reference, {args.entity},is not in workspace. Try another option: hg38 or b37")
-        else:                               # return named entity attributes
+                print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
+        else:                           # return named entity attributes
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)
             attrs = r.json()['attributes']
@@ -883,11 +883,15 @@ def attr_get(args):
             # (but later may provide a way for users to request such, if wanted)
             for k in ["samples", "participants", "pairs"]:
                 attrs.pop(k, None)
-    else:                       # return only workspace attrs (no referenceData)
+    elif args.ws_attrs:                 # return workspace attrs (no referenceData)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
         all_attrs = r.json()['workspace']['attributes']
         attrs = {k:all_attrs[k] for k in all_attrs if not re.search('referenceData', k)}
+    else:                               # return all attributes (workspace + referenceData)
+        r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
+        fapi._check_response_code(r, 200)
+        attrs = r.json()['workspace']['attributes']
 
     if args.attributes:         # return a subset of attributes, if requested
         attrs = {k:attrs[k] for k in set(attrs).intersection(args.attributes)}
@@ -2553,6 +2557,8 @@ def main(argv=None):
     subp.add_argument('-t', '--entity-type', choices=etype_choices,
                       required=etype_required, default=fcconfig.entity_type,
                       help=etype_help)
+    subp.add_argument('-a', '--ws_attrs', action='store_true',
+                      help="Argument retrieves workspace attributes (no referenceData attributes).")
     subp.set_defaults(func=attr_list)
 
     # Copy attributes

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -863,9 +863,15 @@ def attr_get(args):
             r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
             fapi._check_response_code(r, 200)
             all_attrs = r.json()['workspace']['attributes']
-            attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
+            # check for referenceData (b37 or hg38) in workspace
+            attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_', k)}
             if not attrs:
-                print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
+                print(f"There are no reference data available in workspace. Load a reference and try again: hg38 or b37")
+            else:
+                attrs = {k:all_attrs[k] for k in all_attrs if re.search(f'referenceData_{args.entity}', k)}
+                # if the chosen referenceData is not in workspace
+                if not attrs:
+                    print(f"The given reference, {args.entity}, is not in workspace. Try another option: hg38 or b37")
         else:                           # return named entity attrs
             r = fapi.get_entity(args.project, args.workspace, args.entity_type, args.entity)
             fapi._check_response_code(r, 200)


### PR DESCRIPTION
Resolves #152, resolves #153.

`fiss.py`:
- `attr_delete` now works on pairs
- `mop` now recurses into arrays and complex data structures to discover files referenced by attributes
- `attr_get` and `attr_list` are now reference data aware (matching Terra UI), and can return or elide them from results.

`Dockerfile`:
- base image changed to Python 3

`__init__.py`:
- Suppress Python 2 deprecation warning from cryptography module.
