### PR TITLE
Add `get_workflow_cost` [VS-441]

### DIFF
--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1143,6 +1143,23 @@ def get_workflow_outputs(namespace, workspace, submission_id, workflow_id):
                                                             workflow_id)
     return __get(uri)
 
+def get_workflow_cost(namespace, workspace, submission_id, workflow_id):
+    """Request the cost for a workflow in a submission.
+
+    Args:
+        namespace (str): project to which workspace belongs
+        workspace (str): Workspace name
+        submission_id (str): Submission's unique identifier
+        workflow_id (str): Workflow's unique identifier.
+
+    Swagger:
+        https://api.firecloud.org/#!/Submissions/workflowCostInSubmission
+    """
+    uri = "workspaces/{0}/{1}/".format(namespace, workspace)
+    uri += "submissions/{0}/workflows/{1}/cost".format(submission_id,
+                                                         workflow_id)
+    return __get(uri)
+
 def get_submission_queue():
     """ List workflow counts by queueing state.
 

--- a/firecloud/tests/lowlevel_tests.py
+++ b/firecloud/tests/lowlevel_tests.py
@@ -257,6 +257,11 @@ class TestFISSLowLevel(unittest.TestCase):
         """Test get_workflow_outputs()."""
         pass
 
+    @unittest.skip("Not Implemented")
+    def test_get_workflow_cost(self):
+        """Test get_workflow_cost()."""
+        pass
+
     def test_get_workspace(self):
         """Test get_workspace()."""
         r = fapi.get_workspace(self.project, self.workspace)


### PR DESCRIPTION
Adds support for getting workflow-level cost within a submission, i.e. https://api.firecloud.org/#/Submissions/workflowCostInSubmission