### PR TITLE
Fix Iterable import in python3.10.

### DIFF
--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -13,7 +13,6 @@ import os
 import io
 import logging
 import subprocess
-from collections import Iterable
 
 from six.moves.urllib.parse import urlencode, urljoin
 from six import string_types
@@ -26,6 +25,11 @@ from google.oauth2 import id_token
 from firecloud.errors import FireCloudServerError
 from firecloud.fccore import __fcconfig as fcconfig
 from firecloud.__about__ import __version__
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 
 FISS_USER_AGENT = "FISS/" + __version__

--- a/firecloud/fccore.py
+++ b/firecloud/fccore.py
@@ -20,12 +20,16 @@ import os
 import configparser
 import tempfile
 import shutil
-from collections import Iterable
 import subprocess
 from io import IOBase
 from firecloud import __about__
 from google.auth import environment_vars
 from six import string_types
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 class attrdict(dict):
     """ dict whose members can be accessed as attributes, and default value is


### PR DESCRIPTION
You can no longer import Iterable from collections directly in python3.10, which breaks the fiss package in python3.10, and also our repositories that rely on it in python3.10.

This should fix the issue, which is posted here: https://github.com/broadinstitute/fiss/issues/170

Thanks in advance.