### PR TITLE
v0.16.32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@
 build/*
 dist/*
 firecloud.egg-info/*
+/.eggs/*
+
+# my virenv
+.fiss_env
+
+# visual code settings
+.vscode
+firecloud.code-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.5-slim
+FROM python:3.10.5-slim
 
 COPY . /fiss
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,15 +4,16 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 Terms used below:  HL = high level interface, LL = low level interface
 
 v0.16.32 - Changed Dockerfile base image to python 3.10; fixed Python 3.10
-           incompatibility issues; pylint set to minimum version 2.0.0; LL:
+           incompatibility issues; pylint set to minimum version 2.0.0; LL: new
+           functions get_proxy_group, get_storage_cost, and get_bucket_usage;
            added __patch helper to simplify adding wrappers for PATCH API
            calls; enhanced error checking to use the more robust json decoder
            in the requests module; added delete_empty parameter to
            upload_entities; added filter_operator and fields parameters to
-           get_entities_query; added deleteIntermediateOutputFiles,
-           useReferenceDisks, memoryRetryMultiplier, workflowFailureMode, and
-           userComment fields to create_submission; added noWorkspaceOwner and
-           bucketLocation fields to create_workspace and enabled use of
+           get_entities_query; added delete_intermediate_output_files,
+           use_reference_disks, memory_retry_multiplier, workflow_failure_mode,
+           and user_comment fields to create_submission; added noWorkspaceOwner
+           and bucketLocation fields to create_workspace and enabled use of
            multiple authorization domains; added _attr_vlcreate and
            _attr_erlcreate helpers for creating list attribute via
            update_workspace_attributes and update_entity, as well as fixed bugs
@@ -29,9 +30,10 @@ v0.16.32 - Changed Dockerfile base image to python 3.10; fixed Python 3.10
            entity types in the firecloud model); cleaned up return of Terra
            errors to be more human-readable; space_new updated to allow
            multiple authorization domains and set the bucket region for the new
-           workspace; Tests: updated HL tests to include new rename functions,
-           fixed bugs that were due to inaccurate API docs; added LL test for
-           get_entities_query.
+           workspace; mop updated to use API to list files and to filter based
+           on user-supplied submission IDs; Tests: updated HL tests to include
+           new rename functions, fixed bugs that were due to inaccurate API
+           docs; added LL tests for get_entities_query and get_proxy_group.
 
 v0.16.31 - Changed Dockerfile base image to python 3; suppress Python 2
            deprecation warning from cryptography module; HL: mop updated to

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,35 +5,37 @@ Terms used below:  HL = high level interface, LL = low level interface
 
 v0.16.32 - Changed Dockerfile base image to python 3.10; fixed Python 3.10
            incompatibility issues; pylint set to minimum version 2.0.0; LL: new
-           functions get_proxy_group, get_storage_cost, and get_bucket_usage;
-           added __patch helper to simplify adding wrappers for PATCH API
-           calls; enhanced error checking to use the more robust json decoder
-           in the requests module; added delete_empty parameter to
-           upload_entities; added filter_operator and fields parameters to
-           get_entities_query; added delete_intermediate_output_files,
-           use_reference_disks, memory_retry_multiplier, workflow_failure_mode,
-           and user_comment fields to create_submission; added noWorkspaceOwner
-           and bucketLocation fields to create_workspace and enabled use of
-           multiple authorization domains; added _attr_vlcreate and
-           _attr_erlcreate helpers for creating list attribute via
-           update_workspace_attributes and update_entity, as well as fixed bugs
-           in existing helpers _attr_ladd and _attr_lrem; added new functions
-           delete_entities_of_type, rename_entity, rename_entity_type,
-           rename_entity_type_attribute; updated and cleaned up documentation
-           for multiple functions; HL: added entity_rename, attr_rename;
-           _entity_paginator helper updated to take advantage of the fields
-           parameter to speed up queries; config_start updated to use new
-           create_submission fields; attr_get now returns formatted arrays for
-           list attributes in workspaces; attr_set updated to enable creation
-           of value and reference list attributes; attr_delete updated to be
-           completely type agnostic (previously only guaranteed to work on
-           entity types in the firecloud model); cleaned up return of Terra
-           errors to be more human-readable; space_new updated to allow
-           multiple authorization domains and set the bucket region for the new
-           workspace; mop updated to use API to list files and to filter based
-           on user-supplied submission IDs; Tests: updated HL tests to include
-           new rename functions, fixed bugs that were due to inaccurate API
-           docs; added LL tests for get_entities_query and get_proxy_group.
+           new functions: delete_entities_of_type, rename_entity,
+           rename_entity_type, rename_entity_type_attribute, get_proxy_group,
+           get_storage_cost, get_bucket_usage, get_workflow_cost; added __patch
+           helper to simplify adding wrappers for PATCH API calls; enhanced
+           error checking to use the more robust json decoder in the requests
+           module; added delete_empty parameter to upload_entities; added
+           filter_operator and fields parameters to get_entities_query; added
+           delete_intermediate_output_files, use_reference_disks,
+           memory_retry_multiplier, workflow_failure_mode, and user_comment
+           fields to create_submission; added noWorkspaceOwner and
+           bucketLocation fields to create_workspace and enabled use of
+           multiple authorization domains; new helper functions: _attr_vlcreate
+           and _attr_erlcreate for creating list attributes via update_entity
+           and update_workspace_attributes; fixed bugs in existing helper
+           functions _attr_ladd and _attr_lrem; updated and cleaned up
+           documentation for multiple functions; HL: new functions:
+           entity_rename and attr_rename; helper _entity_paginator updated to
+           take advantage of the fields parameter to speed up queries;
+           config_start updated to use new api.create_submission fields;
+           attr_get now returns formatted arrays for list attributes in
+           workspaces; attr_set updated to enable creation of value and
+           reference list attributes; attr_delete updated to be completely type
+           agnostic (previously only guaranteed to work on entity types in the
+           firecloud model); space_new updated to allow multiple authorization
+           domains and set the bucket region for the new workspace; added
+           submission ID filtering to mop, and updated it to use the
+           google-cloud-storage API for file listing rather than the gsutil
+           CLI; cleaned up return of Terra errors to be more human-readable;
+           tests: updated HL tests to include new rename functions and fixed
+           bugs that were due to inaccurate API docs; added LL tests for
+           get_entities_query and get_proxy_group.
 
 v0.16.31 - Changed Dockerfile base image to python 3; suppress Python 2
            deprecation warning from cryptography module; HL: mop updated to

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,36 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.32 - Changed Dockerfile base image to python 3.10; fixed Python 3.10
+           incompatibility issues; pylint set to minimum version 2.0.0; LL:
+           added __patch helper to simplify adding wrappers for PATCH API
+           calls; enhanced error checking to use the more robust json decoder
+           in the requests module; added delete_empty parameter to
+           upload_entities; added filter_operator and fields parameters to
+           get_entities_query; added deleteIntermediateOutputFiles,
+           useReferenceDisks, memoryRetryMultiplier, workflowFailureMode, and
+           userComment fields to create_submission; added noWorkspaceOwner and
+           bucketLocation fields to create_workspace and enabled use of
+           multiple authorization domains; added _attr_vlcreate and
+           _attr_erlcreate helpers for creating list attribute via
+           update_workspace_attributes and update_entity, as well as fixed bugs
+           in existing helpers _attr_ladd and _attr_lrem; added new functions
+           delete_entities_of_type, rename_entity, rename_entity_type,
+           rename_entity_type_attribute; updated and cleaned up documentation
+           for multiple functions; HL: added entity_rename, attr_rename;
+           _entity_paginator helper updated to take advantage of the fields
+           parameter to speed up queries; config_start updated to use new
+           create_submission fields; attr_get now returns formatted arrays for
+           list attributes in workspaces; attr_set updated to enable creation
+           of value and reference list attributes; attr_delete updated to be
+           completely type agnostic (previously only guaranteed to work on
+           entity types in the firecloud model); cleaned up return of Terra
+           errors to be more human-readable; space_new updated to allow
+           multiple authorization domains and set the bucket region for the new
+           workspace; Tests: updated HL tests to include new rename functions,
+           fixed bugs that were due to inaccurate API docs; added LL test for
+           get_entities_query.
+
 v0.16.31 - Changed Dockerfile base image to python 3; suppress Python 2
            deprecation warning from cryptography module; HL: mop updated to
            find files in attributes with array and compound data structure

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.31"
+__version__ = "0.16.32"

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1248,6 +1248,9 @@ def create_submission(wnamespace, workspace, cnamespace, config,
     if user_comment:
         body['userComment'] = user_comment
 
+    if memory_retry_multiplier:
+        body['memoryRetryMultiplier'] = memory_retry_multiplier
+
     return __post(uri, json=body)
 
 def abort_submission(namespace, workspace, submission_id):

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1248,9 +1248,6 @@ def create_submission(wnamespace, workspace, cnamespace, config,
     if user_comment:
         body['userComment'] = user_comment
 
-    if memory_retry_multiplier:
-        body['memoryRetryMultiplier'] = memory_retry_multiplier
-
     return __post(uri, json=body)
 
 def abort_submission(namespace, workspace, submission_id):

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -30,7 +30,6 @@ from firecloud.errors import FireCloudServerError
 from firecloud.fccore import __fcconfig as fcconfig
 from firecloud.__about__ import __version__
 
-
 FISS_USER_AGENT = "FISS/" + __version__
 
 # Set Global Authorized Session

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1176,9 +1176,9 @@ def list_submissions(namespace, workspace):
 
 def create_submission(wnamespace, workspace, cnamespace, config,
                       entity=None, etype=None, expression=None,
-                      use_callcache=True, deleteIntermediateOutputFiles=False,
-                      useReferenceDisks=False, memoryRetryMultiplier=0,
-                      workflowFailureMode="", userComment=""):
+                      use_callcache=True, delete_intermediate_output_files=False,
+                      use_reference_disks=False, memory_retry_multiplier=0,
+                      workflow_failure_mode="", user_comment=""):
     """Submit job in FireCloud workspace.
 
     Args:
@@ -1193,24 +1193,24 @@ def create_submission(wnamespace, workspace, cnamespace, config,
         expression (str): Instead of using entity as the root entity,
             evaluate the root entity from this expression.
         use_callcache (bool): use call cache if applicable (default: true)
-        deleteIntermediateOutputFiles (bool): Whether or not to delete
+        delete_intermediate_output_files (bool): Whether or not to delete
             intermediate output files when the workflow completes. See Cromwell
             docs (https://cromwell.readthedocs.io/en/develop/wf_options/Google)
             for more information
-        useReferenceDisks (bool): Whether or not to use pre-built disks for
+        use_reference_disks (bool): Whether or not to use pre-built disks for
             common genome references
-        memoryRetryMultiplier (float): If a task fails due to running out of
+        memory_retry_multiplier (float): If a task fails due to running out of
             memory and the task has maxRetries in its runtime attributes, then
             it will be retried with its memory multiplied by this amount. See
             Cromwell docs
             (https://cromwell.readthedocs.io/en/develop/cromwell_features/RetryWithMoreMemory)
             for more information
-        workflowFailureMode (str): What happens after a task fails. Choose from
+        workflow_failure_mode (str): What happens after a task fails. Choose from
             ContinueWhilePossible and NoNewCalls. Defaults to NoNewCalls if not
             specified. See Cromwell docs
             (https://cromwell.readthedocs.io/en/develop/execution/ExecutionTwists/#failure-modes)
             for more information.
-        userComment: Freeform user defined description, optional (max length
+        user_comment: Freeform user defined description, optional (max length
             1000 characters)
 
     Swagger:
@@ -1233,20 +1233,20 @@ def create_submission(wnamespace, workspace, cnamespace, config,
     if expression:
         body['expression'] = expression
     
-    if deleteIntermediateOutputFiles:
-        body['deleteIntermediateOutputFiles'] = deleteIntermediateOutputFiles
+    if delete_intermediate_output_files:
+        body['deleteIntermediateOutputFiles'] = delete_intermediate_output_files
     
-    if useReferenceDisks:
-        body['useReferenceDisks'] = useReferenceDisks
+    if use_reference_disks:
+        body['useReferenceDisks'] = use_reference_disks
     
-    if memoryRetryMultiplier:
-        body['memoryRetryMultiplier'] = memoryRetryMultiplier
+    if memory_retry_multiplier:
+        body['memoryRetryMultiplier'] = memory_retry_multiplier
     
-    if workflowFailureMode:
-        body['workflowFailureMode'] = workflowFailureMode
+    if workflow_failure_mode:
+        body['workflowFailureMode'] = workflow_failure_mode
     
-    if userComment:
-        body['userComment'] = userComment
+    if user_comment:
+        body['userComment'] = user_comment
 
     return __post(uri, json=body)
 

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1313,6 +1313,23 @@ def get_workflow_outputs(namespace, workspace, submission_id, workflow_id):
                                                             workflow_id)
     return __get(uri)
 
+def get_workflow_cost(namespace, workspace, submission_id, workflow_id):
+    """Request the cost for a workflow in a submission.
+
+    Args:
+        namespace (str): project to which workspace belongs
+        workspace (str): Workspace name
+        submission_id (str): Submission's unique identifier
+        workflow_id (str): Workflow's unique identifier.
+
+    Swagger:
+        https://api.firecloud.org/#!/Submissions/workflowCostInSubmission
+    """
+    uri = "workspaces/{0}/{1}/".format(namespace, workspace)
+    uri += "submissions/{0}/workflows/{1}/cost".format(submission_id,
+                                                         workflow_id)
+    return __get(uri)
+
 def get_submission_queue():
     """ List workflow counts by queueing state.
 

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1342,6 +1342,28 @@ def list_workspaces(fields=None):
     else:
         return __get("workspaces", params={"fields": fields})
 
+def get_storage_cost(namespace, workspace):
+    """Request average monthly storage cost for workspace.
+    Args:
+        namespace (str): project to which workspace belongs
+        workspace (str): Workspace name
+    Swagger:
+        https://api.firecloud.org/#!/Workspaces/storageCostEstimate
+    """
+    uri = "workspaces/{0}/{1}/storageCostEstimate".format(namespace, workspace)
+    return __get(uri)
+
+def get_bucket_usage(namespace, workspace):
+    """Request google bucket usage for workspace.
+    Args:
+        namespace (str): project to which workspace belongs
+        workspace (str): Workspace name
+    Swagger:
+        https://api.firecloud.org/#!/Workspaces/getBucketUsage
+    """
+    uri = "workspaces/{0}/{1}/bucketUsage".format(namespace, workspace)
+    return __get(uri)
+
 def create_workspace(namespace, name, authorizationDomain="", attributes=None,
                      noWorkspaceOwner=False, bucketLocation=""):
     """Create a new FireCloud Workspace.

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1120,6 +1120,21 @@ def list_billing_projects():
     """
     return __get("profile/billing")
 
+def get_proxy_group(email=None):
+    """Returns the proxy group email for the current user
+
+    Args:
+        email (str): User email whose proxy group to retrieve
+                     if None uses current user email
+
+    Swagger:
+    https://api.firecloud.org/#/Profile/getProxyGroup
+    """
+    if email is None:
+        email = whoami()
+    uri = "proxyGroup/{}".format(email)
+    return __get(uri)
+
 ################
 ### 1.5 Status
 ################
@@ -1526,12 +1541,12 @@ def update_workspace_attributes(namespace, workspace, attrs):
         attrs (list(dict)): List of update operations for workspace attributes.
             Use the helper dictionary construction functions to create these:
 
-            _attr_set()      : Set/Update attribute
-            _attr_rem()      : Remove attribute
-            _attr_ladd()     : Add member to list attribute
-            _attr_lrem()     : Remove member from list attribute
-            _attr_vlcreate() : Create a value-list attribute
-            _attr_erlcreate(): Create an entity-reference list attribute
+            _attr_set()       : Set/Update attribute
+            _attr_rem()       : Remove attribute
+            _attr_ladd()      : Add member to list attribute
+            _attr_lrem()      : Remove member from list attribute
+            _attr_vlcreate()  : Create a value-list attribute
+            _attr_erlcreate() : Create an entity-reference list attribute
 
     Swagger:
         https://api.firecloud.org/#!/Workspaces/updateAttributes
@@ -1578,9 +1593,9 @@ def _attr_lrem(attr, value):
     return {
         "op"                : "RemoveListMember",
         "attributeListName" : attr,
-        "newMember"         : value
+        "removeMember"      : value,
     }
-    
+
 def _attr_vlcreate(attr):
     """Create a 'value-list create' dict for update_workspace_attributes() and
     update_entity()"""

--- a/firecloud/fccore.py
+++ b/firecloud/fccore.py
@@ -20,7 +20,10 @@ import os
 import configparser
 import tempfile
 import shutil
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import subprocess
 from io import IOBase
 from firecloud import __about__

--- a/firecloud/fccore.py
+++ b/firecloud/fccore.py
@@ -20,15 +20,16 @@ import os
 import configparser
 import tempfile
 import shutil
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 import subprocess
 from io import IOBase
 from firecloud import __about__
 from google.auth import environment_vars
 from six import string_types
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 class attrdict(dict):
     """ dict whose members can be accessed as attributes, and default value is

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -104,7 +104,8 @@ def space_unlock(args):
 def space_new(args):
     """ Create a new workspace. """
     r = fapi.create_workspace(args.project, args.workspace,
-                                 args.authdomain, dict())
+                              args.authdomain, dict(),
+                              bucketLocation=args.bucket_region)
     fapi._check_response_code(r, 201)
     if fcconfig.verbosity:
         eprint(r.content)
@@ -232,6 +233,13 @@ def entity_import(args):
                        model)
 
 @fiss_cmd
+def entity_rename(args):
+    """ Rename an entity in a workspace."""
+    r = fapi.rename_entity(args.project, args.workspace, args.entity_type,
+                           args.entity, args.name)
+    fapi._check_response_code(r, 204)
+
+@fiss_cmd
 def set_export(args):
     '''Return a list of lines in TSV form that would suffice to reconstitute a
        container (set) entity, if passed to entity_import.  The first line in
@@ -296,7 +304,7 @@ def __entity_names(entities):
 def __get_entities(args, kind, page_size=1000, handler=__entity_names):
 
     entities = _entity_paginator(args.project, args.workspace, kind,
-                                                page_size=page_size)
+                                 page_size=page_size, fields="name")
     return handler(entities)
 
 @fiss_cmd
@@ -576,8 +584,11 @@ def config_start(args):
         args.entity_type = None
 
     r = fapi.create_submission(args.project, args.workspace,args.namespace,
-                            args.config, args.entity, args.entity_type,
-                            args.expression, use_callcache=cache)
+                               args.config, args.entity, args.entity_type,
+                               args.expression, cache, 
+                               args.delete_intermediates, args.ref_disks,
+                               args.mem_retry_multiplier, args.failure_mode,
+                               args.user_comment)
     fapi._check_response_code(r, 201)
     id = r.json()['submissionId']
 
@@ -901,6 +912,8 @@ def attr_get(args):
     else:                               # return all attributes (workspace + referenceData attrs)
         r = fapi.get_workspace(args.project, args.workspace, fields="workspace.attributes")
         fapi._check_response_code(r, 200)
+        if args.verbose:
+            print(json.dumps(r.json(), indent=2))
         attrs = r.json()['workspace']['attributes']
 
     if args.attributes:         # return a subset of attributes, if requested
@@ -908,6 +921,8 @@ def attr_get(args):
 
     # If some attributes have been collected, return in appropriate format
     if attrs:
+        if args.verbose:
+            print(json.dumps(attrs, indent=2))
         if args.entity:                     # Entity attributes
 
             def textify(thing):
@@ -920,12 +935,21 @@ def attr_get(args):
             object_id = u'entity:%s_id' % args.entity_type
             result['__header__'] = [object_id] + list(attrs.keys())
         else:
-            result = attrs                  # Workspace attributes
+            result = {k:__listify_attr_vals(v) for k,v in attrs.items()}                  # Workspace attributes
     else:
         result = {}
 
     return result
 
+def __listify_attr_vals(val):
+    if isinstance(val, dict) and 'itemsType' in val:
+        if val['itemsType'] == 'AttributeValue':
+            val = val['items']
+        elif val['itemsType'] == 'EntityReference':
+            val = [item['entityName'] for item in val['items']]
+    return '{}'.format(val)
+        
+        
 @fiss_cmd
 def attr_list(args):
     '''Retrieve names of all attributes attached to a given object, either
@@ -945,109 +969,137 @@ def attr_set(args):
     attributes will be set upon that entity, otherwise the attribute will
     be set at the workspace level'''
 
+    value = args.value[0] if len(args.value) == 1 else args.value
     if args.entity_type and args.entity:
-        prompt = "Set {0}={1} for {2}:{3} in {4}/{5}?\n[Y\\n]: ".format(
-                            args.attribute, args.value, args.entity_type,
+        prompt = "Set {0}={1} for {2}:{3} in {4}/{5}?\n[y\\N]: ".format(
+                            args.attribute, value, args.entity_type,
                             args.entity, args.project, args.workspace)
 
         if not (args.yes or _confirm_prompt("", prompt)):
             return 0
 
-        update = fapi._attr_set(args.attribute, args.value)
         r = fapi.update_entity(args.project, args.workspace, args.entity_type,
-                                                        args.entity, [update])
+                               args.entity, _make_updates(args))
         fapi._check_response_code(r, 200)
     else:
-        prompt = "Set {0}={1} in {2}/{3}?\n[Y\\n]: ".format(
-            args.attribute, args.value, args.project, args.workspace
+        prompt = "Set {0}={1} in {2}/{3}?\n[y\\N]: ".format(
+            args.attribute, value, args.project, args.workspace
         )
 
         if not (args.yes or _confirm_prompt("", prompt)):
             return 0
 
-        update = fapi._attr_set(args.attribute, args.value)
         r = fapi.update_workspace_attributes(args.project, args.workspace,
-                                                                [update])
+                                             _make_updates(args))
         fapi._check_response_code(r, 200)
     return 0
 
+def _make_updates(args):
+    ''' Helper function for attr_set - creates the updates payload'''
+    updates = list()
+    if args.ref_etype is not None:
+        updates.append(fapi._attr_erlcreate(args.attribute))
+        if args.verbose:
+            print("Creating Reference List - " + args.attribute)
+        for value in args.value:
+            eref = {"entityType": args.ref_etype,
+                    "entityName": value}
+            updates.append(fapi._attr_ladd(args.attribute, eref))
+        if args.verbose:
+            print(json.dumps(updates, indent=2))
+        return updates
+    if len(args.value) == 1:
+        updates.append(fapi._attr_set(args.attribute, args.value[0]))
+    else:
+        updates.append(fapi._attr_vlcreate(args.attribute))
+        if args.verbose:
+            print("Creating Value List - " + args.attribute)
+        for value in args.value:
+            updates.append(fapi._attr_ladd(args.attribute, value))
+    if args.verbose:
+        print(json.dumps(updates, indent=2))
+    return updates
+
+@fiss_cmd
+def attr_rename(args):
+    ''' Rename attribute: if entity type is specified then the specified
+    attribute will be renamed for that entity type, otherwise the attribute
+    will be renamed on the workspace'''
+    
+    if args.entity_type:
+        prompt = "Rename {} to {} for {}s in {}/{}?\n[y\\N]: ".format(
+                            args.attribute, args.name, args.entity_type,
+                            args.project, args.workspace)
+        if not (args.yes or _confirm_prompt("", prompt)):
+            return 0
+        r = fapi.rename_entity_type_attribute(args.project, args.workspace,
+                                              args.entity_type, args.attribute,
+                                              args.name)
+        fapi._check_response_code(r, 204)
+    # There is no API for renaming workspace attributes, so we create one in
+    # the interest of consistency
+    else:
+        prompt = "Rename {} to {} in {}/{}?\n[y\\N]: ".format(
+                            args.attribute, args.name, args.project,
+                            args.workspace)
+        r = fapi.get_workspace(args.project, args.workspace,
+                               fields="workspace.attributes." + args.attribute +
+                                      ",workspace.attributes." + args.name)
+        fapi._check_response_code(r, 200)
+        updates = list()
+        attrs = r.json()['workspace']['attributes']
+        # Entity attribute rename API errors if the new name already exists, so
+        # we do the same here.
+        if args.name in attrs:
+            eprint("{} already exists in {}/{}".format(args.name, args.project,
+                                                       args.workspace))
+            return 1
+        value = attrs[args.attribute]
+        if isinstance(value, dict):
+            items = value['items']
+            itype = value['itemsType']
+            if itype == "EntityReference":
+                updates.append(fapi._attr_erlcreate(args.name))
+            else:
+                updates.append(fapi._attr_vlcreate(args.name))
+            for item in items:
+                updates.append(fapi._attr_ladd(args.name, item))
+        else:
+            updates.append(fapi._attr_set(args.name, value))
+        r = fapi.update_workspace_attributes(args.project, args.workspace,
+                                             updates)
+        fapi._check_response_code(r, 200)
+        # Don't delete the original attribute if the rename wasn't successful
+        r = fapi.update_workspace_attributes(args.project, args.workspace,
+                                             [fapi._attr_rem(args.attribute)])
+        fapi._check_response_code(r, 200)
+    return 0
 @fiss_cmd
 def attr_delete(args):
     ''' Delete key=value attributes: if entity name & type are specified then
     attributes will be deleted from that entity, otherwise the attribute will
     be removed from the workspace'''
-
-    if args.entity_type and args.entities:
-        # Since there is no attribute deletion endpoint, we must perform 2 steps
-        # here: first we retrieve the entity_ids, and any foreign keys (e.g.
-        # participant_id for sample_id); and then construct a loadfile which
-        # specifies which entities are to have what attributes removed.  Note
-        # that FireCloud uses the magic keyword __DELETE__ to indicate that
-        # an attribute should be deleted from an entity.
-
-        # Step 1: see what entities are present, and filter to those requested
-        entities = _entity_paginator(args.project, args.workspace,
-                                     args.entity_type,
-                                     page_size=1000, filter_terms=None,
-                                     sort_direction="asc")
-        if args.entities:
-            entities = [e for e in entities if e['name'] in args.entities]
-
-        # Step 2: construct a loadfile to delete these attributes
-        attrs = sorted(args.attributes)
-        etype = args.entity_type
-
-        entity_data = []
-        for entity_dict in entities:
-            name = entity_dict['name']
-            line = name
-            # TODO: Fix other types?
-            if etype in ("sample", "pair"):
-                line += "\t" + entity_dict['attributes']['participant']['entityName']
-            if etype == "pair":
-                line += "\t" + entity_dict['attributes']['case_sample']['entityName']
-                line += "\t" + entity_dict['attributes']['control_sample']['entityName']
-            for _ in attrs:
-                line += "\t__DELETE__"
-            # Improve performance by only updating records that have changed
-            entity_data.append(line)
-
-        entity_header = ["entity:" + etype + "_id"]
-        if etype == "sample":
-            entity_header.append("participant_id")
-        if etype == "pair":
-            entity_header += ["participant", "case_sample", "control_sample"]
-        entity_header = '\t'.join(entity_header + list(attrs))
-
-        # Remove attributes from an entity
-        message = "WARNING: this will delete these attributes:\n\n" + \
-                  ','.join(args.attributes) + "\n\n"
-        if args.entities:
-            message += 'on these {0}s:\n\n'.format(args.entity_type) + \
+    
+    updates = [fapi._attr_rem(a) for a in args.attributes]
+    message = "WARNING: this will delete these attributes:\n\n" + \
+              ','.join(args.attributes) + "\n\n"
+    if args.entity_type:
+        if args.entities is not None:
+            message += 'on these {}s:\n\n'.format(args.entity_type) + \
                        ', '.join(args.entities)
         else:
-            message += 'on all {0}s'.format(args.entity_type)
-        message += "\n\nin workspace {0}/{1}\n".format(args.project, args.workspace)
+            message += 'on all {}s'.format(args.entity_type)
+            args.entities = [e['name'] for e in 
+                             _entity_paginator(args.project, args.workspace,
+                                               args.entity_type,
+                                               page_size=1000, fields="name")]
+        message += "\n\nin workspace {}/{}\n".format(args.project,
+                                                     args.workspace)
         if not args.yes and not _confirm_prompt(message):
             return 0
-
-        # TODO: reconcile with other batch updates
-        # Chunk the entities into batches of 500, and upload to FC
-        if args.verbose:
-            print("Batching " + str(len(entity_data)) + " updates to Firecloud...")
-        chunk_len = 500
-        total = int(len(entity_data) / chunk_len) + 1
-        batch = 0
-        for i in range(0, len(entity_data), chunk_len):
-            batch += 1
-            if args.verbose:
-                print("Updating samples {0}-{1}, batch {2}/{3}".format(
-                    i+1, min(i+chunk_len, len(entity_data)), batch, total
-                ))
-            this_data = entity_header + '\n' + '\n'.join(entity_data[i:i+chunk_len])
-
-            # Now push the entity data back to firecloud
-            r = fapi.upload_entities(args.project, args.workspace, this_data)
+        for entity in args.entities:
+            r = fapi.update_entity(args.project, args.workspace,
+                                   args.entity_type, entity, updates)
             fapi._check_response_code(r, 200)
     else:
         message = "WARNING: this will delete the following attributes in " + \
@@ -1056,8 +1108,6 @@ def attr_delete(args):
 
         if not (args.yes or _confirm_prompt(message)):
             return 0
-
-        updates = [fapi._attr_rem(a) for a in args.attributes]
         r = fapi.update_workspace_attributes(args.project, args.workspace,
                                              updates)
         fapi._check_response_code(r, 200)
@@ -1896,7 +1946,8 @@ def _nonempty_project(string):
     return value
 
 def _entity_paginator(namespace, workspace, etype, page_size=500,
-                            filter_terms=None, sort_direction="asc"):
+                      filter_terms=None, sort_direction="asc",
+                      filter_operator=None, fields=None):
     """Pages through the get_entities_query endpoint to get all entities in
        the workspace without crashing.
     """
@@ -1906,7 +1957,8 @@ def _entity_paginator(namespace, workspace, etype, page_size=500,
     # Make initial request
     r = fapi.get_entities_query(namespace, workspace, etype, page=page,
                            page_size=page_size, sort_direction=sort_direction,
-                           filter_terms=filter_terms)
+                           filter_terms=filter_terms, filter_operator=filter_operator,
+                           fields=fields)
     fapi._check_response_code(r, 200)
 
     response_body = r.json()
@@ -1921,7 +1973,8 @@ def _entity_paginator(namespace, workspace, etype, page_size=500,
     while page <= total_pages:
         r = fapi.get_entities_query(namespace, workspace, etype, page=page,
                                page_size=page_size, sort_direction=sort_direction,
-                               filter_terms=filter_terms)
+                               filter_terms=filter_terms, filter_operator=filter_operator,
+                               fields=fields)
         fapi._check_response_code(r, 200)
         entities = r.json()['results']
         all_entities.extend(entities)
@@ -2021,7 +2074,7 @@ def __pretty_print_fc_exception(e):
         print_traceback(trback)
     try:
         # Attempt to unpack error message as JSON
-        e = json.loads(e.args[0])
+        e = json.loads(str(e))
         # Default to 'FireCloud' if component which gave error was not specified
         source = ' (' + e.get('source','FireCloud') + ')'
         msg = e['message']
@@ -2030,6 +2083,15 @@ def __pretty_print_fc_exception(e):
             if match:
                 msg = pattern[1] % (match.group(*(pattern[2])))
                 break
+        else:
+            if fcconfig.verbosity > 1:
+                e['message'] = json.loads(msg)
+                eprint(json.dumps(e, indent=2))
+            msgs = json.loads(msg)
+            msg = msgs['message']
+            if 'causes' in msgs:
+                msg += ' - ' + ', '.join(cause['message'] for cause in msgs['causes'])
+            
     except Exception as je:
         # Could not unpack error to JSON, fallback to original message
         if isinstance(code, str):
@@ -2176,11 +2238,16 @@ def main(argv=None):
     # Create Workspace
     subp = subparsers.add_parser('space_new', parents=[workspace_parent],
                                  description='Create new workspace')
-    phelp = 'Limit access to the workspace to a specific authorization ' \
-            'domain. For dbGaP-controlled access (domain name: ' \
-            'dbGapAuthorizedUsers) you must have linked NIH credentials to ' \
-            'your account.'
-    subp.add_argument('--authdomain', default="", help=phelp)
+    phelp = 'Limit workspace access to specific authorization domains. For ' \
+            'dbGaP-controlled access (domain name: dbGapAuthorizedUsers) ' \
+            'you must have linked NIH credentials to your account.'
+    subp.add_argument('--authdomain', nargs="*", help=phelp)
+    subp.add_argument('--bucket_region',
+                      help='Region (NOT multi-region) in which bucket ' +
+                      'attached to the workspace should be created. If not ' +
+                      "provided, the bucket will be created in the 'US' " +
+                      'multi-region. E.G. us-central1, ' +
+                      'northamerica-northeast1')
     subp.set_defaults(func=space_new)
 
     # Determine existence of workspace
@@ -2327,6 +2394,13 @@ def main(argv=None):
         'sset_list', description='List sample sets in a workspace',
         parents=[workspace_parent])
     subp.set_defaults(func=sset_list)
+    
+    # Rename entity in a workspace
+    subp = subparsers.add_parser(
+        'entity_rename', description='Rename entity in a workspace',
+        parents=[workspace_parent, etype_parent, entity_parent])
+    subp.add_argument('-n', '--name', required=True, help='New entity name')
+    subp.set_defaults(func=entity_rename)
 
     # Delete entity in a workspace
     subp = subparsers.add_parser(
@@ -2550,16 +2624,30 @@ def main(argv=None):
     subp.set_defaults(func=attr_get)
 
     subp = subparsers.add_parser('attr_set', parents=[workspace_parent],
-                                 description="Set attributes on a workspace")
+                                 description="Set attributes in a workspace")
     subp.add_argument('-a', '--attribute', required=True, metavar='attr',
-                      help='Name of attribute to set')
-    subp.add_argument('-v', '--value', required=True, help='Attribute value')
+                      help='Name of attribute to set.')
+    subp.add_argument('-r', '--ref_etype',
+                      help='Create an entity reference list attribute for. ' +
+                      'which members must be entities of the given type.')
+    subp.add_argument('-v', '--value', required=True, nargs='+',
+                      help='Attribute value. Multiple values will result in ' +
+                      'the creation of a list attribute.')
     subp.add_argument('-t', '--entity-type', choices=etype_choices,
-                      required=etype_required, default=fcconfig.entity_type,
-                      help=etype_help)
+                      help="Type of entity being modified")
     subp.add_argument('-e', '--entity', help="Entity to set attribute on")
     subp.set_defaults(func=attr_set)
 
+    subp = subparsers.add_parser('attr_rename', parents=[workspace_parent],
+                                 description="Rename attributes in a workspace")
+    subp.add_argument('-a', '--attribute', required=True, metavar='attr',
+                      help='Name of attribute to rename.')
+    subp.add_argument('-n', '--name', required=True,
+                      help='New attribute name.')
+    subp.add_argument('-t', '--entity-type',
+                      help="Entity type to rename attribute of")
+    subp.set_defaults(func=attr_rename)
+    
     subp = subparsers.add_parser('attr_list', parents=[workspace_parent],
         description='Retrieve names of attributes attached to given entity. ' +
                     'If no entity Type+Name is given, workspace-level ' +
@@ -2586,7 +2674,8 @@ def main(argv=None):
     subp.add_argument('-t', '--entity-type', choices=etype_choices,
                       required=etype_required, default=fcconfig.entity_type,
                       help=etype_help)
-    subp.add_argument('-e', '--entities', nargs='*', help='FireCloud entities')
+    subp.add_argument('-e', '--entities', nargs='*', metavar="entity",
+                      help='FireCloud entities')
     subp.set_defaults(func=attr_delete)
 
     # Set null sentinel values
@@ -2650,6 +2739,29 @@ def main(argv=None):
     subp.add_argument('-x', '--expression', help=expr_help, default='')
     subp.add_argument('-C', '--cache', default=True,
         help='boolean: use previously cached results if possible [%(default)s]')
+    subp.add_argument('-d', '--delete_intermediates', action='store_true',
+                      help='Whether or not to delete intermediate output ' +
+                      'files when the workflow completes. See Cromwell docs ' +
+                      '(https://cromwell.readthedocs.io/en/develop/wf_options/Google)' +
+                      ' for more information.')
+    subp.add_argument('-r', '--ref_disks', action='store_true',
+                      help='Whether or not to use pre-built disks for ' +
+                      'common genome references.')
+    subp.add_argument('-m', '--mem_retry_multiplier', type=float,
+                      help='If a task fails due to running out of memory and ' +
+                      'the task has maxRetries in its runtime attributes, ' +
+                      'then it will be retried with its memory multiplied by ' +
+                      'this amount. See Cromwell docs ' +
+                      '(https://cromwell.readthedocs.io/en/develop/cromwell_features/RetryWithMoreMemory)' +
+                      ' for more information.')
+    subp.add_argument('-f', '--failure_mode',
+                      choices=['NoNewCalls', 'ContinueWhilePossible'],
+                      help='What happens after a task fails. Defaults to ' +
+                      'NoNewCalls if not specified. See Cromwell docs ' +
+                      '(https://cromwell.readthedocs.io/en/develop/execution/ExecutionTwists/#failure-modes)' +
+                      ' for more information.')
+    subp.add_argument('-u', '--user_comment', help='Freeform user defined ' +
+                      'description (max length 1000 characters).')
     subp.set_defaults(func=config_start)
     
     # Abort a running method configuration

--- a/firecloud/tests/highlevel_tests.py
+++ b/firecloud/tests/highlevel_tests.py
@@ -31,7 +31,8 @@ def call_cli(*args):
 class Capturing(list):
     def __enter__(self):
         self._stdout = sys.stdout
-        sys.stdout = self._stringio = StringIO()
+        self._stringio = StringIO()
+        sys.stdout = self._stringio
         return self
     def __exit__(self, *args):
         self.extend(self._stringio.getvalue().splitlines())
@@ -123,7 +124,7 @@ class TestFISSHighLevel(unittest.TestCase):
 
         # Verify UNLOCKED, again by trying to delete
         r = fapi.delete_workspace(self.project, self.workspace)
-        fapi._check_response_code(r, 202)
+        fapi._check_response_code(r, [200, 202])
 
         # Lastly, recreate space in case this test was run in series with others
         r = fapi.create_workspace(self.project, self.workspace)
@@ -166,13 +167,26 @@ class TestFISSHighLevel(unittest.TestCase):
 
     def test_attr_workspace(self):
         name = "workspace_attr"
+        rename = "workspace_attr_v2"
         value = "test_value"
-        call_func("-y", "attr_set", "-p", self.project, "-w", self.workspace,
-                   "-a", name, "-v", value)
+        ret = call_cli("-y", "attr_set", "-p", self.project, "-w",
+                       self.workspace, "-a", name, "-v", value)
+        self.assertEqual(0, ret)
 
-        result = call_func("attr_get", "-p", self.project, "-w", self.workspace,
-                    "-a", name)
+        result = call_func("attr_get", "-p", self.project, "-w",
+                           self.workspace, "-a", name)
+        logging.debug(str(result))
         self.assertEqual(result[name], value)
+        
+        ret = call_cli("-y", "attr_rename", "-p", self.project, "-w",
+                       self.workspace, "-a", name, "-n", rename)
+        self.assertEqual(0, ret)
+
+        result = call_func("attr_get", "-p", self.project, "-w",
+                           self.workspace, "-a", rename)
+        logging.debug(str(result))
+        self.assertEqual(result[rename], value)
+        
 
     def load_entities(self):
         # To potentially save time, sanity check if entities already exist
@@ -198,16 +212,26 @@ class TestFISSHighLevel(unittest.TestCase):
         call_func(*(args + ("-f", os.path.join(datapath, "pairset_attr.tsv"))))
         print("\t... done loading data ...", file=sys.stderr)
     
-    def test_entity_delete(self):
+    def test_entity_rename_delete(self):
         self.load_entities()
-        ret = call_cli("-y", "entity_delete", "-p", self.project,
+        ret = call_cli("-y", "entity_rename", "-p", self.project,
                        "-w", self.workspace, "-t", "sample_set",
-                       "-e", "SS-NT")
+                       "-e", "SS-NT", "-n", "SS-NB")
         self.assertEqual(0, ret)
         with Capturing() as output:
             ret = call_cli("sset_list", "-p", self.project,
                            "-w", self.workspace)            
         self.assertNotIn("SS-NT", output)
+        self.assertIn("SS-NB", output)
+        
+        ret = call_cli("-y", "entity_delete", "-p", self.project,
+                       "-w", self.workspace, "-t", "sample_set",
+                       "-e", "SS-NB")
+        self.assertEqual(0, ret)
+        with Capturing() as output:
+            ret = call_cli("sset_list", "-p", self.project,
+                           "-w", self.workspace)            
+        self.assertNotIn("SS-NB", output)
     
     def test_entity_tsv(self):
         self.load_entities()
@@ -231,19 +255,24 @@ class TestFISSHighLevel(unittest.TestCase):
 
         # Now call attr_set on a sample_set, followed by attr_get
         ret = call_cli("-y", "attr_set", "-p", self.project, "-w", self.workspace,
-                   "-t", "sample_set", "-e", "SS-TP", "-a", "set_attr_1", "-v", "Value-E")
+                   "-t", "sample_set", "-e", "SS-TP", "-a", "set_attr_2", "-v", "Value-E")
         self.assertEqual(0, ret)
 
         with Capturing() as output:
             ret = call_cli("attr_get", "-p", self.project, "-w", self.workspace,
-                             "-t", "sample_set", "-e", "SS-TP", "-a", "set_attr_1")
+                             "-t", "sample_set", "-e", "SS-TP", "-a", "set_attr_2")
         self.assertEqual(0, ret)
         output = '\n'.join(output)
         logging.debug(output)
-        self.assertEqual(output, "entity:sample_set_id\tset_attr_1\nSS-TP\tValue-E")
+        self.assertEqual(output, "entity:sample_set_id\tset_attr_2\nSS-TP\tValue-E")
 
-    def test_attr_del(self):
+    def test_attr_ren_del(self):
         self.load_entities()
+        ret = call_cli("-y", "attr_rename", "-p", self.project, "-w", self.workspace,
+                   "-t", "sample_set", "-a", "set_attr_2", "-n",
+                   "set_attr_3")
+        self.assertEqual(0, ret)
+        
         ret = call_cli("-y", "attr_delete", "-p", self.project, "-w", self.workspace,
                    "-t", "sample_set", "-e", "SS-NT", "-a", "set_attr_1")
         self.assertEqual(0, ret)
@@ -256,7 +285,7 @@ class TestFISSHighLevel(unittest.TestCase):
         self.assertEqual(0, ret)
         output = '\n'.join(output)
         logging.debug(output)
-        self.assertEqual(output, "entity:sample_set_id\tset_attr_2\nSS-NT\tValue-D")
+        self.assertEqual(output, "entity:sample_set_id\tset_attr_3\nSS-NT\tValue-D")
 
     def test_attr_pair(self):
         self.load_entities()
@@ -477,7 +506,6 @@ class TestFISSHighLevel(unittest.TestCase):
             result = call_func(*(('sset_export', '-e', '_No_SuCh_SeT_') + args))
         except FireCloudServerError as e:
             self.assertEqual(e.code, 404)
-
 def main():
     nose.main()
 

--- a/firecloud/tests/lowlevel_tests.py
+++ b/firecloud/tests/lowlevel_tests.py
@@ -296,6 +296,11 @@ class TestFISSLowLevel(unittest.TestCase):
         """Test get_workflow_outputs()."""
         pass
 
+    @unittest.skip("Not Implemented")
+    def test_get_workflow_cost(self):
+        """Test get_workflow_cost()."""
+        pass
+
     def test_get_workspace(self):
         """Test get_workspace()."""
         r = fapi.get_workspace(self.project, self.workspace)

--- a/firecloud/tests/lowlevel_tests.py
+++ b/firecloud/tests/lowlevel_tests.py
@@ -238,6 +238,12 @@ class TestFISSLowLevel(unittest.TestCase):
         """Test get_method_configurations()."""
         pass
 
+    def test_get_proxy_group(self):
+        """Test get_proxy_group()."""
+        r = fapi.get_proxy_group()
+        print(r.status_code, r.content)
+        self.assertEqual(r.status_code, 200)
+
     @unittest.skip("Not Implemented")
     def test_get_repository_config(self):
         """Test get_repository_config()."""

--- a/firecloud/tests/lowlevel_tests.py
+++ b/firecloud/tests/lowlevel_tests.py
@@ -177,6 +177,11 @@ class TestFISSLowLevel(unittest.TestCase):
         pass
 
     @unittest.skip("Not Implemented")
+    def test_get_bucket_usage(self):
+        """Test get_bucket_usage()."""
+        pass
+
+    @unittest.skip("Not Implemented")
     def test_get_config_template(self):
         """Test get_config_template()."""
         pass
@@ -277,6 +282,11 @@ class TestFISSLowLevel(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
     @unittest.skip("Not Implemented")
+    def test_get_storage_cost(self):
+        """Test get_storage_cost()."""
+        pass
+
+    @unittest.skip("Not Implemented")
     def test_get_submission(self):
         """Test get_submission()."""
         pass
@@ -287,6 +297,11 @@ class TestFISSLowLevel(unittest.TestCase):
         pass
 
     @unittest.skip("Not Implemented")
+    def test_get_workflow_cost(self):
+        """Test get_workflow_cost()."""
+        pass
+
+    @unittest.skip("Not Implemented")
     def test_get_workflow_metadata(self):
         """Test get_workflow_metadata()."""
         pass
@@ -294,11 +309,6 @@ class TestFISSLowLevel(unittest.TestCase):
     @unittest.skip("Not Implemented")
     def test_get_workflow_outputs(self):
         """Test get_workflow_outputs()."""
-        pass
-
-    @unittest.skip("Not Implemented")
-    def test_get_workflow_cost(self):
-        """Test get_workflow_cost()."""
         pass
 
     def test_get_workspace(self):

--- a/firecloud/tests/lowlevel_tests.py
+++ b/firecloud/tests/lowlevel_tests.py
@@ -104,8 +104,18 @@ class TestFISSLowLevel(unittest.TestCase):
         pass
 
     @unittest.skip("Not Implemented")
-    def test_delete_entity(self):
-        """Test delete_entity()."""
+    def test_delete_entities(self):
+        """Test delete_entities()."""
+        pass
+
+    @unittest.skip("Not Implemented")
+    def test_delete_entities_of_type(self):
+        """Test delete_entities_of_type()."""
+        pass
+
+    @unittest.skip("Not Implemented")
+    def test_delete_entitiy_type(self):
+        """Test delete_entity_type()."""
         pass
     
     @unittest.skip("Not Implemented")
@@ -131,6 +141,11 @@ class TestFISSLowLevel(unittest.TestCase):
     @unittest.skip("Not Implemented")
     def test_delete_participant_set(self):
         """Test delete_participant_set()."""
+        pass
+
+    @unittest.skip("Not Implemented")
+    def test_delete_repository_config(self):
+        """Test delete_repository_config()."""
         pass
 
     @unittest.skip("Not Implemented")
@@ -173,6 +188,14 @@ class TestFISSLowLevel(unittest.TestCase):
                                "participant")
         print(r.status_code, r.content)
         self.assertEqual(r.status_code, 200)
+    
+    def test_get_entities_query(self):
+        """Test get_entities_query()."""
+        r =  fapi.get_entities_query(self.project,
+                                     self.workspace,
+                                     "participant")
+        print(r.status_code, r.content)
+        self.assertEqual(r.status_code, 200)
 
     @unittest.skip("Not Implemented")
     def test_get_entities_tsv(self):
@@ -208,6 +231,11 @@ class TestFISSLowLevel(unittest.TestCase):
     @unittest.skip("Not Implemented")
     def test_get_inputs_outputs(self):
         """Test get_inputs_outputs()."""
+        pass
+
+    @unittest.skip("Not Implemented")
+    def test_get_method_configurations(self):
+        """Test get_method_configurations()."""
         pass
 
     @unittest.skip("Not Implemented")
@@ -250,6 +278,11 @@ class TestFISSLowLevel(unittest.TestCase):
     @unittest.skip("Not Implemented")
     def test_get_submission_queue(self):
         """Test get_submission_queue()."""
+        pass
+
+    @unittest.skip("Not Implemented")
+    def test_get_workflow_metadata(self):
+        """Test get_workflow_metadata()."""
         pass
 
     @unittest.skip("Not Implemented")
@@ -350,6 +383,21 @@ class TestFISSLowLevel(unittest.TestCase):
         pass
 
     @unittest.skip("Not Implemented")
+    def test_rename_entity(self):
+        """Test rename_entity()."""
+        pass
+
+    @unittest.skip("Not Implemented")
+    def test_rename_entity_type(self):
+        """Test rename_entity_type()."""
+        pass
+
+    @unittest.skip("Not Implemented")
+    def test_rename_entity_type_attribute(self):
+        """Test rename_entity_type_attribute()."""
+        pass
+
+    @unittest.skip("Not Implemented")
     def test_rename_workspace_config(self):
         """Test rename_workspace_config()."""
         pass
@@ -364,6 +412,11 @@ class TestFISSLowLevel(unittest.TestCase):
         r =  fapi.unlock_workspace(self.project, self.workspace)
         print(r.status_code, r.content)
         self.assertEqual(r.status_code, 204)
+
+    @unittest.skip("Not Implemented")
+    def test_update_entity(self):
+        """Test update_entity()."""
+        pass
 
     @unittest.skip("Not Implemented")
     def test_update_repository_config_acl(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ requests
 nose
 pylint
 google-auth
+google-cloud-storage
 six

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
         'setuptools>=40.3.0',
         'six',
         'nose',
-        'pylint==1.7.2'
+        'pylint>=2.0.0'
     ],
     classifiers = [
         "Programming Language :: Python :: 2",

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ setup(
     test_suite = 'nose.collector',
     install_requires = [
         'google-auth>=1.6.3',
+        'google-cloud-storage>=1.36.1',
         'pydot',
         'requests[security]',
         'setuptools>=40.3.0',


### PR DESCRIPTION
* Changed Dockerfile base image to python 3.10
* Fixed Python 3.10 incompatibility issues (fixes #170)
* pylint set to minimum version 2.0.0 (fixes #168)

### `api.py`:
* added `__patch()` helper to simplify adding wrappers for `PATCH` API calls
* enhanced error checking to use the more robust json decoder in the `requests` module
* `upload_entities()`: added `delete_empty` parameter
* `get_entities_query()`: added `filter_operator` and `fields` parameters
* `create_submission()`: added `delete_intermediate_output_files`, `use_reference_disks`, `memory_retry_multiplier`, `workflow_failure_mode`, and `user_comment` fields (fixes #165, fixes #169)
* `create_workspace()`: added `noWorkspaceOwner` and `bucketLocation` fields and enabled use of multiple authorization domains (fixes #171)
* new helper functions: `_attr_vlcreate()` and `_attr_erlcreate()` for creating list attribute via `update_workspace_attributes()` and `update_entity()` (resolves #99)
* fixed bugs in existing helper functions `_attr_ladd()` and `_attr_lrem()`
* new functions:
   - `delete_entities_of_type()`
   - `rename_entity()`
   - `rename_entity_type()`
   - `rename_entity_type_attribute()`
   - `get_proxy_group()`
   - `get_storage_cost()`
   - `get_bucket_usage()`
   - `get_workflow_cost()` (resolves #144)
* updated and cleaned up documentation for multiple functions

### `fiss.py`:
* new functions:
   - `entity_rename()`
   - `attr_rename()`
* function updates:
   - helper `_entity_paginator()` updated to take advantage of the `fields` parameter to speed up queries
   - `config_start()` updated to use new `api.create_submission()` fields
   - `attr_get()` now returns formatted arrays for list attributes in workspaces
   - `attr_set()` updated to enable creation of value and reference list attributes
   - `attr_delete()` updated to be completely type agnostic (previously only guaranteed to work on entity types in the firecloud model)
   - `space_new()` updated to allow multiple authorization domains and set the bucket region for the new workspace
   - `mop()`:
      * Added submission ID filtering (resolves #158)
      * Now uses `google-cloud-storage` API for file listing rather than `gsutil` CLI
* Cleaned up return of Terra errors to be more human-readable

### `highlevel_tests.py`:
* updated include new rename functions
* fixed bugs that were due to inaccurate API docs

### `lowlevel_tests.py`:
* added test for `get_entities_query()`.
* added test for `get_proxy_group()`