### PR TITLE
v0.16.33

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,10 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
-v0.16.33 - HL: added space_size.
+v0.16.33 - HL: added space_size, space_cost; hotfixes: fixed Python 2 compatibility;
+           blocked google-auth versions with restrictive clock-skew and enabled
+           later versions with modifiable clock-skew, increasing clock-skew
+           when appropriate.
 
 v0.16.32 - Changed Dockerfile base image to python 3.10; fixed Python 3.10
            incompatibility issues; pylint set to minimum version 2.0.0; LL: new

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.33 - HL: added space_size.
+
 v0.16.32 - Changed Dockerfile base image to python 3.10; fixed Python 3.10
            incompatibility issues; pylint set to minimum version 2.0.0; LL: new
            new functions: delete_entities_of_type, rename_entity,

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.32"
+__version__ = "0.16.33"

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -28,6 +28,7 @@ from google.oauth2 import id_token
 
 from firecloud.errors import FireCloudServerError
 from firecloud.fccore import __fcconfig as fcconfig
+from firecloud.fccore import release_tuple_from_version_string
 from firecloud.__about__ import __version__
 
 FISS_USER_AGENT = "FISS/" + __version__
@@ -52,9 +53,14 @@ def _set_session():
             __SESSION = AuthorizedSession(google.auth.default(['https://www.googleapis.com/auth/userinfo.profile',
                                                                'https://www.googleapis.com/auth/userinfo.email'])[0])
             health()
-            __USER_ID = id_token.verify_oauth2_token(__SESSION.credentials.id_token,
-                                                     Request(session=__SESSION),
-                                                     clock_skew_in_seconds=10)['email']
+            # google.auth 2.1.0 introduced a restrictive clock skew that was unmodifiable until 2.3.2
+            if release_tuple_from_version_string(google.auth.__version__) >= (2,3,2):
+                __USER_ID = id_token.verify_oauth2_token(__SESSION.credentials.id_token,
+                                                         Request(session=__SESSION),
+                                                         clock_skew_in_seconds=10)['email']
+            else:
+                __USER_ID = id_token.verify_oauth2_token(__SESSION.credentials.id_token,
+                                                         Request(session=__SESSION))['email']
         except AttributeError:
             __USER_ID = __SESSION.credentials.service_account_email
         except (DefaultCredentialsError, RefreshError) as gae:
@@ -1365,7 +1371,7 @@ def get_storage_cost(namespace, workspace):
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
     Swagger:
-        https://api.firecloud.org/#!/Workspaces/storageCostEstimate
+        https://api.firecloud.org/#/Workspaces/getStorageCostEstimate
     """
     uri = "workspaces/{0}/{1}/storageCostEstimate".format(namespace, workspace)
     return __get(uri)

--- a/firecloud/fccore.py
+++ b/firecloud/fccore.py
@@ -21,6 +21,7 @@ import configparser
 import tempfile
 import shutil
 import subprocess
+import re
 from io import IOBase
 from firecloud import __about__
 from google.auth import environment_vars
@@ -218,5 +219,47 @@ def edit_file(name, backup=None):
     subprocess.call([__EDITOR__, name])
     current_tolm  = os.stat(name).st_mtime
     return current_tolm != previous_tolm
+
+
+# From PEP-440:
+# https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
+VERSION_PATTERN = r"""
+    v?
+    (?:
+        (?:(?P<epoch>[0-9]+)!)?                           # epoch
+        (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
+        (?P<pre>                                          # pre-release
+            [-_\.]?
+            (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
+            [-_\.]?
+            (?P<pre_n>[0-9]+)?
+        )?
+        (?P<post>                                         # post release
+            (?:-(?P<post_n1>[0-9]+))
+            |
+            (?:
+                [-_\.]?
+                (?P<post_l>post|rev|r)
+                [-_\.]?
+                (?P<post_n2>[0-9]+)?
+            )
+        )?
+        (?P<dev>                                          # dev release
+            [-_\.]?
+            (?P<dev_l>dev)
+            [-_\.]?
+            (?P<dev_n>[0-9]+)?
+        )?
+    )
+    (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
+"""
+
+version_regex = re.compile(
+    r"^\s*" + VERSION_PATTERN + r"\s*$",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+def release_tuple_from_version_string(version_string):
+    return tuple(int(val) for val in version_regex.match(version_string).group('release').split('.'))
 
 # }}}

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -121,8 +121,15 @@ def space_info(args):
 
 @fiss_cmd
 def space_size(args):
-    """ Get metadata for a workspace. """
+    """ Get storage size of a workspace. """
     r = fapi.get_bucket_usage(args.project, args.workspace)
+    fapi._check_response_code(r, 200)
+    return r.text
+
+@fiss_cmd
+def space_cost(args):
+    """ Get average monthly storage cost of a workspace. """
+    r = fapi.get_storage_cost(args.project, args.workspace)
     fapi._check_response_code(r, 200)
     return r.text
 
@@ -2288,10 +2295,16 @@ def main(argv=None):
                                  description='Show workspace information')
     subp.set_defaults(func=space_info)
 
-    # Get workspace information
+    # Get workspace size
     subp = subparsers.add_parser('space_size', parents=[workspace_parent],
                                  description='Show workspace bucket usage')
     subp.set_defaults(func=space_size)
+
+    # Get workspace monthly cost
+    subp = subparsers.add_parser('space_cost', parents=[workspace_parent],
+                                 description='Show workspace average monthly' +
+                                 ' cost')
+    subp.set_defaults(func=space_cost)
 
     # List workspaces
     subp = subparsers.add_parser('space_list',

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -120,6 +120,13 @@ def space_info(args):
     return r.text
 
 @fiss_cmd
+def space_size(args):
+    """ Get metadata for a workspace. """
+    r = fapi.get_bucket_usage(args.project, args.workspace)
+    fapi._check_response_code(r, 200)
+    return r.text
+
+@fiss_cmd
 def space_delete(args):
     """ Delete a workspace. """
     message = "WARNING: this will delete workspace: \n\t{0}/{1}".format(
@@ -2280,6 +2287,11 @@ def main(argv=None):
     subp = subparsers.add_parser('space_info', parents=[workspace_parent],
                                  description='Show workspace information')
     subp.set_defaults(func=space_info)
+
+    # Get workspace information
+    subp = subparsers.add_parser('space_size', parents=[workspace_parent],
+                                 description='Show workspace bucket usage')
+    subp.set_defaults(func=space_size)
 
     # List workspaces
     subp = subparsers.add_parser('space_list',

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -1327,7 +1327,7 @@ def mop(args):
                             bucket_prefix)
 
     ## Now list files present in the bucket
-    def list_blob_gen(bucket_name: str):
+    def list_blob_gen(bucket_name):
         """Generate the list of blobs in the bucket and size of each blob
 
         Args:

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
     },
     test_suite = 'nose.collector',
     install_requires = [
-        'google-auth>=1.6.3',
+        'google-auth>=1.6.3,!=2.1.*,!=2.2.*,!=2.3.0,!=2.3.1',
         'google-cloud-storage>=1.36.1',
         'pydot',
         'requests[security]',


### PR DESCRIPTION
#### `fccore.py`:
* Added function to extract release tuple from a standard version string (from [PEP 440](https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions))

#### `api.py`:
* parameter added to allow for clock skew in Oauth call
* added version check of `google.auth` to determine availability of clock skew parameter

#### `fiss.py`:
* added `space_size()`
* added `space_cost()`
* removed Python 3 syntax that broke Python 2 compatibility

#### `setup.py`:
* blocked versions of `google.auth` with restrictive clock skew defaults and no way to modify them (2.1.0-2.3.1)