### PR TITLE
v0.16.34

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,11 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
-v0.16.34 - 
+v0.16.34 - Hotfixes: in Python 2 map() returns a list, in Python 3, map()
+           returns a generator object - tasks that returned map(f(x),iterable)
+           now return a list comprehension; clock-skew now checks for argument
+           presence at runtime rather than google.auth version; mop HL function
+           updated to account for new output path structure in Terra.
 
 v0.16.33 - HL: added space_size, space_cost; hotfixes: fixed Python 2 compatibility;
            blocked google-auth versions with restrictive clock-skew and enabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 =======================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.34 - 
+
 v0.16.33 - HL: added space_size, space_cost; hotfixes: fixed Python 2 compatibility;
            blocked google-auth versions with restrictive clock-skew and enabled
            later versions with modifiable clock-skew, increasing clock-skew

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.33"
+__version__ = "0.16.34"

--- a/firecloud/fccore.py
+++ b/firecloud/fccore.py
@@ -21,7 +21,6 @@ import configparser
 import tempfile
 import shutil
 import subprocess
-import re
 from io import IOBase
 from firecloud import __about__
 from google.auth import environment_vars
@@ -219,47 +218,5 @@ def edit_file(name, backup=None):
     subprocess.call([__EDITOR__, name])
     current_tolm  = os.stat(name).st_mtime
     return current_tolm != previous_tolm
-
-
-# From PEP-440:
-# https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
-VERSION_PATTERN = r"""
-    v?
-    (?:
-        (?:(?P<epoch>[0-9]+)!)?                           # epoch
-        (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
-        (?P<pre>                                          # pre-release
-            [-_\.]?
-            (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
-            [-_\.]?
-            (?P<pre_n>[0-9]+)?
-        )?
-        (?P<post>                                         # post release
-            (?:-(?P<post_n1>[0-9]+))
-            |
-            (?:
-                [-_\.]?
-                (?P<post_l>post|rev|r)
-                [-_\.]?
-                (?P<post_n2>[0-9]+)?
-            )
-        )?
-        (?P<dev>                                          # dev release
-            [-_\.]?
-            (?P<dev_l>dev)
-            [-_\.]?
-            (?P<dev_n>[0-9]+)?
-        )?
-    )
-    (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
-"""
-
-version_regex = re.compile(
-    r"^\s*" + VERSION_PATTERN + r"\s*$",
-    re.VERBOSE | re.IGNORECASE,
-)
-
-def release_tuple_from_version_string(version_string):
-    return tuple(int(val) for val in version_regex.match(version_string).group('release').split('.'))
 
 # }}}

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -476,7 +476,7 @@ def meth_acl(args):
                                                     args.snapshot_id)
     fapi._check_response_code(r, 200)
     acls = sorted(r.json(), key=lambda k: k['user'])
-    return map(lambda acl: '{0}\t{1}'.format(acl['user'], acl['role']), acls)
+    return ['{0}\t{1}'.format(acl['user'], acl['role']) for acl in acls]
 
 @fiss_cmd
 def meth_set_acl(args):
@@ -668,7 +668,7 @@ def config_acl(args):
                                                     args.snapshot_id)
     fapi._check_response_code(r, 200)
     acls = sorted(r.json(), key=lambda k: k['user'])
-    return map(lambda acl: '{0}\t{1}'.format(acl['user'], acl['role']), acls)
+    return ['{0}\t{1}'.format(acl['user'], acl['role']) for acl in acls]
 
 @fiss_cmd
 def config_set_acl(args):


### PR DESCRIPTION
Fixes #179

#### `api.py`
- check for presence of clock skew argument rather than check `google.auth.__version__`
#### `fiss.py`
- `meth_acl`/`config_acl`
   * changed `map(f(x),iterable)` returns into list comprehensions to make py2/3 consistent
- `mop` updated to account for change in Terra output directory structure
#### `fccore.py`
- removed version string parser in favor of above check for the clock skew argument