### PR TITLE
v0.16.35

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,11 @@
-=======================================================================
+================================================================================
 Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
-=======================================================================
+================================================================================
 Terms used below:  HL = high level interface, LL = low level interface
+
+v0.16.35 - Hotfix: mop returned errors in Python 2 when trying to read the
+           workspace bucket - bucket listing updated to use the workspace
+           billing project, and the error report was cleaned up.
 
 v0.16.34 - Hotfixes: in Python 2 map() returns a list, in Python 3, map()
            returns a generator object - tasks that returned map(f(x),iterable)

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.34"
+__version__ = "0.16.35"

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -1388,7 +1388,7 @@ def mop(args):
         
     except Exception as e:
         eprint("Error retrieving files from bucket:" +
-               "\n\t{}: {}".format(type(e).__name__), e)
+               "\n\t{}: {}".format(type(e).__name__, e))
         return 1
 
     if args.verbose:

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -1343,7 +1343,7 @@ def mop(args):
         Yields:
             tuple: File name and the size of the file
         """
-        client_st = storage.Client()
+        client_st = storage.Client(project=args.project)
         blobs = client_st.list_blobs(bucket_name)
         for blob in blobs:
             yield ("gs://{}/{}".format(blob.bucket.name, blob.name), int(blob.size))
@@ -1388,7 +1388,7 @@ def mop(args):
         
     except Exception as e:
         eprint("Error retrieving files from bucket:" +
-               "\n\t{}\n\t{}".format(str(e), e.output))
+               "\n\t{}: {}".format(type(e).__name__), e)
         return 1
 
     if args.verbose:


### PR DESCRIPTION
### Hotfix
`mop` was failing for Python 2.7 installations when the user didn't set a default project, and the bucket listing error message was broken. To fix this, bucket listing was updated to use the workspace billing project, and the bucket listing exception catching code was corrected.