### PR TITLE
[CORE-321] Update v1/getBucketUsage and v1/getStorageCostEstimate APIs to v2/getStorageEstimateV2 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ firecloud.egg-info/*
 # visual code settings
 .vscode
 firecloud.code-workspace
+
+# IntelliJ IDEA settings
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ firecloud.egg-info/*
 # visual code settings
 .vscode
 firecloud.code-workspace
-
-# IntelliJ IDEA settings
-.idea

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1395,9 +1395,9 @@ def get_storage_cost(namespace, workspace):
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
     Swagger:
-        https://api.firecloud.org/#/Workspaces/getStorageCostEstimate
+        https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2
     """
-    uri = "workspaces/{0}/{1}/storageCostEstimate".format(namespace, workspace)
+    uri = "workspaces/v2/{0}/{1}/storageCostEstimate".format(namespace, workspace)
     return __get(uri)
 
 def get_bucket_usage(namespace, workspace):
@@ -1405,11 +1405,8 @@ def get_bucket_usage(namespace, workspace):
     Args:
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
-    Swagger:
-        https://api.firecloud.org/#!/Workspaces/getBucketUsage
     """
-    uri = "workspaces/{0}/{1}/bucketUsage".format(namespace, workspace)
-    return __get(uri)
+    return get_storage_cost(namespace, workspace)
 
 def create_workspace(namespace, name, authorizationDomain="", attributes=None,
                      noWorkspaceOwner=False, bucketLocation=""):

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1395,9 +1395,9 @@ def get_storage_cost(namespace, workspace):
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
     Swagger:
-        https://api.firecloud.org/#/Workspaces/getStorageCostEstimate
+        https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2
     """
-    uri = "workspaces/{0}/{1}/storageCostEstimate".format(namespace, workspace)
+    uri = "workspaces/v2/{0}/{1}/storageCostEstimate".format(namespace, workspace)
     return __get(uri)
 
 def get_bucket_usage(namespace, workspace):
@@ -1406,9 +1406,9 @@ def get_bucket_usage(namespace, workspace):
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
     Swagger:
-        https://api.firecloud.org/#!/Workspaces/getBucketUsage
+        https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2
     """
-    uri = "workspaces/{0}/{1}/bucketUsage".format(namespace, workspace)
+    uri = "workspaces/v2/{0}/{1}/storageCostEstimate".format(namespace, workspace)
     return __get(uri)
 
 def create_workspace(namespace, name, authorizationDomain="", attributes=None,

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1395,9 +1395,9 @@ def get_storage_cost(namespace, workspace):
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
     Swagger:
-        https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2
+        https://api.firecloud.org/#/Workspaces/getStorageCostEstimate
     """
-    uri = "workspaces/v2/{0}/{1}/storageCostEstimate".format(namespace, workspace)
+    uri = "workspaces/{0}/{1}/storageCostEstimate".format(namespace, workspace)
     return __get(uri)
 
 def get_bucket_usage(namespace, workspace):
@@ -1406,9 +1406,9 @@ def get_bucket_usage(namespace, workspace):
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
     Swagger:
-        https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2
+        https://api.firecloud.org/#!/Workspaces/getBucketUsage
     """
-    uri = "workspaces/v2/{0}/{1}/storageCostEstimate".format(namespace, workspace)
+    uri = "workspaces/{0}/{1}/bucketUsage".format(namespace, workspace)
     return __get(uri)
 
 def create_workspace(namespace, name, authorizationDomain="", attributes=None,


### PR DESCRIPTION
As part of our ongoing efforts to improve Terra Workspace APIs, the following deprecated API endpoints will be permanently removed:

- **Deprecated**
   - [https://api.firecloud.org/#/Workspaces/getBucketUsage](https://api.firecloud.org/#/Workspaces/getBucketUsage)
   - [https://api.firecloud.org/#/Workspaces/getStorageCostEstimate]( https://api.firecloud.org/#/Workspaces/getStorageCostEstimate)
- **Alternative**
   -  [https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2](https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2)
