### PR TITLE
v0.16.38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ firecloud.egg-info/*
 # visual code settings
 .vscode
 firecloud.code-workspace
+
+# IntelliJ IDEA settings
+.idea

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,10 @@ Change Log for FISSFC: the (Fi)recloud (S)ervice (S)elector
 ================================================================================
 Terms used below:  HL = high level interface, LL = low level interface
 
+v0.16.38 - LL: updated get_storage_cost and get_bucket_usage to use the new
+           getStorageCostEstimateV2 API; HL: updated space_size and space_cost
+           to return the applicable fields.
+
 v0.16.37 - LL: enhanced get_workflow_metadata to include the arguments
            include_key, exclude_key, and expand_sub_workflows to match the API.
 

--- a/firecloud/__about__.py
+++ b/firecloud/__about__.py
@@ -1,2 +1,2 @@
 # Package version
-__version__ = "0.16.37"
+__version__ = "0.16.38"

--- a/firecloud/api.py
+++ b/firecloud/api.py
@@ -1395,9 +1395,9 @@ def get_storage_cost(namespace, workspace):
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
     Swagger:
-        https://api.firecloud.org/#/Workspaces/getStorageCostEstimate
+        https://api.firecloud.org/#/WorkspacesV2/getStorageCostEstimateV2
     """
-    uri = "workspaces/{0}/{1}/storageCostEstimate".format(namespace, workspace)
+    uri = "workspaces/v2/{0}/{1}/storageCostEstimate".format(namespace, workspace)
     return __get(uri)
 
 def get_bucket_usage(namespace, workspace):
@@ -1405,11 +1405,8 @@ def get_bucket_usage(namespace, workspace):
     Args:
         namespace (str): project to which workspace belongs
         workspace (str): Workspace name
-    Swagger:
-        https://api.firecloud.org/#!/Workspaces/getBucketUsage
     """
-    uri = "workspaces/{0}/{1}/bucketUsage".format(namespace, workspace)
-    return __get(uri)
+    return get_storage_cost(namespace, workspace)
 
 def create_workspace(namespace, name, authorizationDomain="", attributes=None,
                      noWorkspaceOwner=False, bucketLocation=""):

--- a/firecloud/fiss.py
+++ b/firecloud/fiss.py
@@ -124,14 +124,14 @@ def space_size(args):
     """ Get storage size of a workspace. """
     r = fapi.get_bucket_usage(args.project, args.workspace)
     fapi._check_response_code(r, 200)
-    return r.text
+    return r.json()["usageInBytes"]
 
 @fiss_cmd
 def space_cost(args):
     """ Get average monthly storage cost of a workspace. """
     r = fapi.get_storage_cost(args.project, args.workspace)
     fapi._check_response_code(r, 200)
-    return r.text
+    return r.json()["estimate"]
 
 @fiss_cmd
 def space_delete(args):


### PR DESCRIPTION
#### `api.py`:
- `get_storage_cost` and `get_bucket_usage` updated to use the new `getStorageCostEstimateV2` API (original APIs deprecated)

#### `fiss.py`:
- updated `space_size` and `space_cost` to return the applicable fields.