### PR TITLE
Pin setuptools to workaround ``package_index`` removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<80.3.0"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
Fix https://github.com/broadinstitute/fiss/issues/192 , which was caused by the removal of `package_index` from setuptools in https://github.com/pypa/setuptools/pull/4963 .

Note that I needed to use `setuptools.build_meta:__legacy__` as `build-backend` (instead of the usual `setuptools.build_meta`) because otherwise `python3 -m build` would fail with:

```
ModuleNotFoundError: No module named 'firecloud'
```