### PR TITLE
Replace deprecated SafeConfigParser with ConfigParser

### DIFF
--- a/firecloud/fccore.py
+++ b/firecloud/fccore.py
@@ -134,7 +134,7 @@ def config_parse(files=None, config=None, config_profile=".fissconfig", **kwargs
     local_config = config
     config = __fcconfig
 
-    cfgparser = configparser.SafeConfigParser()
+    cfgparser = configparser.ConfigParser()
 
     filenames = list()
 


### PR DESCRIPTION
configparser.SafeConfigParser was deprecated in Python 3.2 and removed in Python 3.12.

issue #194